### PR TITLE
Add sponsor logos and reorganize partner section

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,21 +181,59 @@
                 <p class="section-subtitle">Terima kasih kepada mitra yang mendukung perjalanan komunitas kami</p>
             </div>
 
-            <div class="sponsors-grid">
-                <div class="sponsor-card">
-                    <h4>ACCUMART JOGJA</h4>
+            <div class="sponsor-categories">
+                <div class="sponsor-category">
+                    <h3 class="sponsor-category-title">Business Partners</h3>
+                    <div class="sponsors-grid">
+                        <div class="sponsor-card">
+                            <div class="sponsor-logo">
+                                <img src="image%20assets/sponsor%20assets/accumart.jpg" alt="Logo Accumart Jogja">
+                            </div>
+                            <h4>ACCUMART JOGJA</h4>
+                        </div>
+                        <div class="sponsor-card">
+                            <div class="sponsor-logo">
+                                <img src="image%20assets/sponsor%20assets/basrengdomini.jpg" alt="Logo Basreng Domini">
+                            </div>
+                            <h4>BASRENG DOMINI</h4>
+                        </div>
+                        <div class="sponsor-card">
+                            <div class="sponsor-logo">
+                                <img src="image%20assets/sponsor%20assets/kencanaproperty.jpg" alt="Logo Kencana Property">
+                            </div>
+                            <h4>KENCANA PROPERTY</h4>
+                        </div>
+                        <div class="sponsor-card">
+                            <div class="sponsor-logo">
+                                <img src="image%20assets/sponsor%20assets/marketphone.jpg" alt="Logo Market Phone">
+                            </div>
+                            <h4>MARKET PHONE</h4>
+                        </div>
+                    </div>
                 </div>
-                <div class="sponsor-card">
-                    <h4>BASRENG DOMINI</h4>
-                </div>
-                <div class="sponsor-card">
-                    <h4>KOMUNITAS BERBAGI YOGYAKARTA</h4>
-                </div>
-                <div class="sponsor-card">
-                    <h4>KENCANA PROPERTY</h4>
-                </div>
-                <div class="sponsor-card">
-                    <h4>MARKET PHONE</h4>
+
+                <div class="sponsor-category">
+                    <h3 class="sponsor-category-title">Community Partners</h3>
+                    <div class="sponsors-grid">
+                        <div class="sponsor-card">
+                            <div class="sponsor-logo">
+                                <img src="image%20assets/sponsor%20assets/komunitasberbagiyogyakarta.jpg" alt="Logo Komunitas Berbagi Yogyakarta">
+                            </div>
+                            <h4>KOMUNITAS BERBAGI YOGYAKARTA</h4>
+                        </div>
+                        <div class="sponsor-card sponsor-card--placeholder">
+                            <span>Segera Hadir</span>
+                        </div>
+                        <div class="sponsor-card sponsor-card--placeholder">
+                            <span>Segera Hadir</span>
+                        </div>
+                        <div class="sponsor-card sponsor-card--placeholder">
+                            <span>Segera Hadir</span>
+                        </div>
+                        <div class="sponsor-card sponsor-card--placeholder">
+                            <span>Segera Hadir</span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -481,33 +481,87 @@ nav {
 }
 
 /* Sponsors Grid */
+.sponsor-categories {
+    display: flex;
+    flex-direction: column;
+    gap: 60px;
+}
+
+.sponsor-category-title {
+    font-size: 1.6rem;
+    color: var(--primary-red);
+    margin-bottom: 20px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
 .sponsors-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 30px;
-    margin-top: 40px;
+    margin-top: 20px;
 }
 
 .sponsor-card {
     background: var(--white);
-    padding: 30px;
+    padding: 30px 25px;
     text-align: center;
     border: 1px solid var(--border-color);
     transition: var(--transition);
     opacity: 0;
     animation: fadeInUp 0.8s ease forwards;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    min-height: 230px;
 }
 
 .sponsor-card:hover {
-    transform: scale(1.05);
+    transform: translateY(-8px);
     box-shadow: var(--shadow-hover);
     border-color: var(--primary-red);
 }
 
+.sponsor-logo {
+    width: 100%;
+    max-width: 200px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.sponsor-logo img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.1));
+}
+
 .sponsor-card h4 {
     color: var(--black);
-    font-size: 1.1rem;
+    font-size: 1.05rem;
     font-weight: 600;
+    letter-spacing: 1px;
+}
+
+.sponsor-card--placeholder {
+    background: var(--light-gray);
+    border: 2px dashed var(--border-color);
+    color: var(--gray);
+    gap: 10px;
+}
+
+.sponsor-card--placeholder span {
+    font-size: 1rem;
+    font-style: italic;
+}
+
+.sponsor-card--placeholder:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: var(--border-color);
 }
 
 /* Events Section (Empty for now) */


### PR DESCRIPTION
## Summary
- display sponsor logos from the assets directory inside the Partner & Sponsor section
- split the section into dedicated business and community partner groups with placeholders for upcoming community partners

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce6f429798832897bc72e2489130f6