### PR TITLE
Fix mobile gallery script error when loader missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,25 +8,29 @@ const scrollTop = document.getElementById('scrollTop');
 const themeToggle = document.getElementById('themeToggle');
 
 // Hide loader when page loads
-window.addEventListener('load', () => {
-    setTimeout(() => {
-        loader.classList.add('hidden');
-    }, 500);
-});
+if (loader) {
+    window.addEventListener('load', () => {
+        setTimeout(() => {
+            loader.classList.add('hidden');
+        }, 500);
+    });
+}
 
 // Mobile Menu Toggle
-menuToggle.addEventListener('click', () => {
-    menuToggle.classList.toggle('active');
-    navMenu.classList.toggle('active');
-});
-
-// Close mobile menu when clicking nav links
-navLinks.forEach(link => {
-    link.addEventListener('click', () => {
-        menuToggle.classList.remove('active');
-        navMenu.classList.remove('active');
+if (menuToggle && navMenu) {
+    menuToggle.addEventListener('click', () => {
+        menuToggle.classList.toggle('active');
+        navMenu.classList.toggle('active');
     });
-});
+
+    // Close mobile menu when clicking nav links
+    navLinks.forEach(link => {
+        link.addEventListener('click', () => {
+            menuToggle.classList.remove('active');
+            navMenu.classList.remove('active');
+        });
+    });
+}
 
 // Header scroll effect
 let lastScrollY = 0;
@@ -50,12 +54,14 @@ window.addEventListener('scroll', () => {
 });
 
 // Scroll to top functionality
-scrollTop.addEventListener('click', () => {
-    window.scrollTo({
-        top: 0,
-        behavior: 'smooth'
+if (scrollTop) {
+    scrollTop.addEventListener('click', () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
     });
-});
+}
 
 // Smooth scroll for anchor links
 document.querySelectorAll('a[href^="#"]').forEach(anchor => {
@@ -74,22 +80,24 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
 });
 
 // Dark Mode Toggle
-themeToggle.addEventListener('click', () => {
-    const currentTheme = document.documentElement.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    
-    document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
-    
-    // Change emoji based on theme
-    themeToggle.textContent = newTheme === 'dark' ? '🌙' : '☀️';
-});
+if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
-// Load saved theme
-const savedTheme = localStorage.getItem('theme');
-if (savedTheme) {
-    document.documentElement.setAttribute('data-theme', savedTheme);
-    themeToggle.textContent = savedTheme === 'dark' ? '🌙' : '☀️';
+        document.documentElement.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+
+        // Change emoji based on theme
+        themeToggle.textContent = newTheme === 'dark' ? '🌙' : '☀️';
+    });
+
+    // Load saved theme
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+        document.documentElement.setAttribute('data-theme', savedTheme);
+        themeToggle.textContent = savedTheme === 'dark' ? '🌙' : '☀️';
+    }
 }
 
 // Intersection Observer for animations


### PR DESCRIPTION
## Summary
- prevent the shared JavaScript bundle from throwing when the loader element is absent on secondary pages such as the gallery
- guard menu, scroll-to-top, and theme toggle logic so navigation and theme controls keep working across pages that omit optional elements

## Testing
- Manual mobile verification of galeri.html (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68cfb5da6720832890bc64ca8de0f4c0