### PR TITLE
Add Instagram links to partner cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,19 +191,19 @@
                     <button class="carousel-btn carousel-btn-left" id="businessLeft">‹</button>
                     <div class="sponsor-carousel" id="businessCarousel">
                         <div class="sponsor-track">
-                            <div class="sponsor-card">
+                            <a class="sponsor-card" href="https://www.instagram.com/kencana_property112" target="_blank" rel="noopener noreferrer">
                                 <div class="sponsor-logo">
                                     <img src="/assets/partners/business/kencanaproperty.jpg" alt="Kencana Property" loading="lazy">
                                 </div>
                                 <h4 class="sponsor-name">KENCANA PROPERTY</h4>
-                            </div>
+                            </a>
 
-                            <div class="sponsor-card">
+                            <a class="sponsor-card" href="https://www.instagram.com/marketphone70" target="_blank" rel="noopener noreferrer">
                                 <div class="sponsor-logo">
                                     <img src="/assets/partners/business/marketphone.jpg" alt="Market Phone" loading="lazy">
                                 </div>
                                 <h4 class="sponsor-name">MARKET PHONE</h4>
-                            </div>
+                            </a>
 
                             <div class="sponsor-card">
                                 <div class="sponsor-logo">
@@ -212,12 +212,12 @@
                                 <h4 class="sponsor-name">ACCUMART JOGJA</h4>
                             </div>
 
-                            <div class="sponsor-card">
+                            <a class="sponsor-card" href="https://www.instagram.com/basreng_domini" target="_blank" rel="noopener noreferrer">
                                 <div class="sponsor-logo">
                                     <img src="/assets/partners/business/basrengdomini.jpg" alt="Basreng Domini" loading="lazy">
                                 </div>
                                 <h4 class="sponsor-name">BASRENG DOMINI</h4>
-                            </div>
+                            </a>
 
                             <!-- Placeholder cards for future sponsors -->
                             <div class="sponsor-card placeholder">
@@ -246,12 +246,12 @@
                     <button class="carousel-btn carousel-btn-left" id="communityLeft">‹</button>
                     <div class="sponsor-carousel" id="communityCarousel">
                         <div class="sponsor-track">
-                            <div class="sponsor-card">
+                            <a class="sponsor-card" href="https://www.instagram.com/komunitasberbagiyogyakarta" target="_blank" rel="noopener noreferrer">
                                 <div class="sponsor-logo">
                                     <img src="/assets/partners/community/komunitasberbagiyogyakarta.jpg" alt="Komunitas Berbagi Yogyakarta" loading="lazy">
                                 </div>
                                 <h4 class="sponsor-name">KOMUNITAS BERBAGI YOGYAKARTA</h4>
-                            </div>
+                            </a>
 
                             <!-- Placeholder cards for future community partners -->
                             <div class="sponsor-card placeholder">

--- a/style.css
+++ b/style.css
@@ -543,6 +543,7 @@ nav {
 /* Sponsor Card */
 .sponsor-card {
     flex: 0 0 250px;
+    display: block;
     background: var(--white);
     border: 2px solid var(--border-color);
     border-radius: 12px;
@@ -550,6 +551,8 @@ nav {
     text-align: center;
     transition: var(--transition);
     cursor: pointer;
+    color: inherit;
+    text-decoration: none;
 }
 
 .sponsor-card:hover {


### PR DESCRIPTION
## Summary
- add Instagram links to the partner cards in the sponsor carousel
- update sponsor card styling so linked cards retain existing appearance

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d12a243ec4832880cbd5d6d1204957