### PR TITLE
Add profile imagery to Hubungi Kami contact cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,14 +149,18 @@
 
             <div class="contact-grid">
                 <div class="contact-card">
-                    <div class="contact-icon">👤</div>
+                    <div class="contact-avatar">
+                        <img src="/assets/profile/founder-profile.jpg" alt="Founder KCI" loading="lazy">
+                    </div>
                     <h3>Founder KCI</h3>
                     <p>Hubungi pendiri komunitas untuk informasi lebih lanjut tentang visi dan misi KCI</p>
                     <a href="https://wa.me/6287884924385" target="_blank" class="btn-whatsapp">Hubungi via WhatsApp</a>
                 </div>
 
                 <div class="contact-card">
-                    <div class="contact-icon">👥</div>
+                    <div class="contact-avatar">
+                        <img src="/assets/profile/admin-kci-profile.jpg" alt="Admin KCI" loading="lazy">
+                    </div>
                     <h3>Admin KCI</h3>
                     <p>Kontak admin untuk keperluan administrasi, pendaftaran, dan informasi kegiatan</p>
                     <a href="https://wa.me/6285641877775" target="_blank" class="btn-whatsapp">Hubungi via WhatsApp</a>

--- a/style.css
+++ b/style.css
@@ -400,6 +400,27 @@ nav {
     animation: fadeInUp 0.8s ease 0.4s forwards;
 }
 
+.contact-avatar {
+    width: 120px;
+    height: 120px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 4px solid rgba(207, 83, 79, 0.2);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+}
+
+.contact-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: var(--transition);
+}
+
+.contact-card:hover .contact-avatar img {
+    transform: scale(1.05);
+}
+
 .contact-card:hover {
     transform: translateY(-5px);
     box-shadow: var(--shadow-hover);


### PR DESCRIPTION
## Summary
- replace the contact card emojis in the Hubungi Kami section with the new founder and admin profile photos
- add styling for the new circular avatars so the images display cleanly within the contact cards

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d13de5dc3883288c8d7106e7a03fa2