### PR TITLE
Add animated dragon ornament to hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,14 @@
     <section class="hero" id="beranda">
         <div class="container hero-content">
             <div class="chinese-border"></div>
+            <div class="dragon-ornament" aria-hidden="true">
+                <svg viewBox="0 0 200 120" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M20 90c25-40 70-60 130-40" />
+                    <path d="M40 100c30-30 60-40 110-20" opacity="0.8" />
+                    <path d="M146 30c8 6 17 12 24 20-8 3-15 8-20 15" />
+                    <path d="M130 18c10 4 20 10 28 18-11 4-20 10-26 18" opacity="0.7" />
+                </svg>
+            </div>
             <div class="floating-lanterns" aria-hidden="true">
                 <span class="lantern"></span>
                 <span class="lantern"></span>

--- a/style.css
+++ b/style.css
@@ -212,9 +212,49 @@ nav {
     z-index: 2;
 }
 
+.dragon-ornament {
+    position: absolute;
+    top: -60px;
+    right: 60px;
+    width: 220px;
+    color: var(--gold);
+    opacity: 0.45;
+    pointer-events: none;
+    animation: dragonPulse 18s ease-in-out infinite;
+    transform-origin: center;
+}
+
+.dragon-ornament svg {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.dragon-ornament path {
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.12));
+}
+
 .hero-content > :not(.floating-lanterns) {
     position: relative;
     z-index: 1;
+}
+
+@keyframes dragonPulse {
+    0%, 100% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.05);
+    }
+}
+
+@media (max-width: 1024px) {
+    .dragon-ornament {
+        width: 160px;
+        top: -40px;
+        right: 30px;
+        opacity: 0.35;
+    }
 }
 
 .floating-lanterns {
@@ -936,6 +976,10 @@ footer {
 
     .menu-toggle.active span:nth-child(3) {
         transform: rotate(-45deg) translate(5px, -5px);
+    }
+
+    .dragon-ornament {
+        display: none;
     }
 
     .hero h1 {


### PR DESCRIPTION
## Summary
- add an inline SVG dragon ornament to the hero section to complement the existing border
- style the ornament with absolute positioning, subtle animation, and responsive behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d14a0d5c6c8328ab948f0e63bd68f9