### PR TITLE
Add favicon links to public pages

### DIFF
--- a/galeri.html
+++ b/galeri.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Galeri — Komunitas Chinese Indonesia</title>
   <meta name="description" content="Dokumentasi kegiatan Komunitas Chinese Indonesia (KCI)."/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
+  <link rel="shortcut icon" href="/favicon.ico"/>
+  <link rel="manifest" href="/site.webmanifest"/>
   <link rel="stylesheet" href="style.css"/>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Komunitas Chinese Indonesia - Unity in Diversity</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/index.php
+++ b/index.php
@@ -48,6 +48,11 @@ while ($row = $stmt->fetch()) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($settings['site_title'] ?? 'Komunitas Chinese Indonesia'); ?> - Unity in Diversity</title>
     <meta name="description" content="<?php echo htmlspecialchars($settings['site_description'] ?? 'Komunitas Chinese Indonesia - Wadah persaudaraan dan pelestarian budaya Tionghoa di Indonesia'); ?>">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="style.css">
     <?php if (!empty($settings['google_analytics'])): ?>
     <!-- Google Analytics -->

--- a/tentang_kci.html
+++ b/tentang_kci.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tentang KCI — Komunitas Chinese Indonesia</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="manifest" href="/site.webmanifest" />
   <link rel="stylesheet" href="style.css" />
   <meta name="description" content="Tentang KCI: latar belakang, visi, dan komitmen Komunitas Chinese Indonesia (KCI)." />
 </head>


### PR DESCRIPTION
## Summary
- add favicon and manifest link tags to all public pages so the site icon is exposed to browsers and search engines

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d76a83b9d083289c635f55e796a135