### PR TITLE
feat: Phase 1 Next.js CMS frontend

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE=http://localhost:3000/api

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/.next
+/out

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,3 +1,24 @@
-# Web Frontend (placeholder)
+# KCI CMS Frontend
 
-The JS migration keeps the legacy PHP templates in place until a modern frontend is ready. When design work begins, scaffold a Next.js or Remix app in this directory and use the `apps/api` service as the data source.
+This package contains the Phase 1 static admin console for the Komunitas Chinese Indonesia (KCI) site. It is a Next.js App Router project that consumes the existing Fastify API to manage events, media, links, and messages.
+
+## Getting started
+
+```bash
+# from the repository root
+cp apps/web/.env.local.example apps/web/.env.local # optional helper
+npm install
+npm run dev --workspace web
+```
+
+The CMS expects `NEXT_PUBLIC_API_BASE` to point to the deployed API, e.g. `http://localhost:3000/api` during local development.
+
+## Available scripts
+
+- `npm run dev` – start the Next.js dev server.
+- `npm run build` – run the production build.
+- `npm run build:cms` – build and export the static site to `apps/web/out` for deployment under `/cms` on the main domain.
+
+## Static export configuration
+
+`next.config.js` sets `output: 'export'` together with `basePath`/`assetPrefix` so the generated site can be uploaded to `/cms` on the production server. See the project brief for the accompanying Apache rewrite rules.

--- a/apps/web/app/admin/events/page.js
+++ b/apps/web/app/admin/events/page.js
@@ -1,0 +1,298 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { apiGet, apiPost } from '../../../lib/api';
+import { fromJakartaInputValue, toJakartaInputValue } from '../../../lib/utils';
+
+function createEmptyEvent() {
+  return {
+    title: '',
+    slug: '',
+    summary: '',
+    description: '',
+    location: '',
+    starts_at: toJakartaInputValue(new Date().toISOString()),
+    ends_at: '',
+    hero_image_url: '',
+    is_published: false,
+  };
+}
+
+export default function EventsPage() {
+  const { data, error, isLoading, mutate } = useSWR('/events', () => apiGet('/events'));
+  const events = useMemo(() => data?.events ?? [], [data]);
+
+  const [showModal, setShowModal] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [draft, setDraft] = useState(() => createEmptyEvent());
+  const [editingId, setEditingId] = useState(null);
+
+  function openCreate() {
+    setDraft(createEmptyEvent());
+    setEditingId(null);
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function openEdit(event) {
+    setDraft({
+      ...event,
+      summary: event.summary ?? '',
+      description: event.description ?? '',
+      location: event.location ?? '',
+      hero_image_url: event.hero_image_url ?? '',
+      starts_at: toJakartaInputValue(event.starts_at),
+      ends_at: toJakartaInputValue(event.ends_at),
+    });
+    setEditingId(event.id);
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function closeModal() {
+    setShowModal(false);
+    setSaving(false);
+    setFormError('');
+  }
+
+  function updateField(field, value) {
+    setDraft((previous) => ({ ...previous, [field]: value }));
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSaving(true);
+    setFormError('');
+
+    const payload = {
+      id: editingId ?? undefined,
+      title: draft.title,
+      slug: draft.slug,
+      summary: draft.summary || null,
+      description: draft.description || null,
+      location: draft.location || null,
+      hero_image_url: draft.hero_image_url || null,
+      is_published: draft.is_published,
+      starts_at: fromJakartaInputValue(draft.starts_at) ?? new Date().toISOString(),
+      ends_at: draft.ends_at ? fromJakartaInputValue(draft.ends_at) : null,
+    };
+
+    try {
+      await apiPost('/events', payload);
+      await mutate();
+      closeModal();
+    } catch (err) {
+      setFormError(err.message || 'Failed to save event');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function togglePublish(eventRecord) {
+    try {
+      await apiPost('/events', {
+        ...eventRecord,
+        summary: eventRecord.summary ?? null,
+        description: eventRecord.description ?? null,
+        location: eventRecord.location ?? null,
+        hero_image_url: eventRecord.hero_image_url ?? null,
+        starts_at: eventRecord.starts_at,
+        ends_at: eventRecord.ends_at,
+        is_published: !eventRecord.is_published,
+      });
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to update publish status');
+    }
+  }
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Events</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Manage upcoming events. Toggle publish status to control visibility on the site.
+          </p>
+        </div>
+        <button className="button" onClick={openCreate}>
+          New event
+        </button>
+      </header>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading events…</p>
+      ) : events.length === 0 ? (
+        <div className="empty-state">No events yet. Create your first event.</div>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Starts</th>
+              <th>Ends</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((eventItem) => (
+              <tr key={eventItem.id}>
+                <td>
+                  <div className="stack">
+                    <strong>{eventItem.title}</strong>
+                    <span style={{ color: '#666', fontSize: '0.875rem' }}>{eventItem.slug}</span>
+                  </div>
+                </td>
+                <td>{new Date(eventItem.starts_at).toLocaleString('en-US', { timeZone: 'Asia/Jakarta' })}</td>
+                <td>
+                  {eventItem.ends_at
+                    ? new Date(eventItem.ends_at).toLocaleString('en-US', { timeZone: 'Asia/Jakarta' })
+                    : '—'}
+                </td>
+                <td>
+                  <span className="badge" style={{ background: eventItem.is_published ? '#dcfce7' : '#fee2e2', color: eventItem.is_published ? '#166534' : '#7f1d1d' }}>
+                    {eventItem.is_published ? 'Published' : 'Draft'}
+                  </span>
+                </td>
+                <td>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <button className="button secondary" onClick={() => openEdit(eventItem)}>
+                      Edit
+                    </button>
+                    <button className="button" onClick={() => togglePublish(eventItem)}>
+                      {eventItem.is_published ? 'Unpublish' : 'Publish'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {showModal ? (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <div className="modal">
+            <header className="stack" style={{ marginBottom: '1rem' }}>
+              <h2 style={{ margin: 0 }}>{editingId ? 'Edit event' : 'Create event'}</h2>
+              <p style={{ margin: 0, color: '#555' }}>
+                Fill in the event details. Times are saved in Jakarta time (UTC+7).
+              </p>
+            </header>
+            {formError ? <div className="alert">{formError}</div> : null}
+            <form className="form-grid" onSubmit={handleSubmit}>
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="title">Title</label>
+                  <input
+                    id="title"
+                    type="text"
+                    required
+                    value={draft.title}
+                    onChange={(event) => updateField('title', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="slug">Slug</label>
+                  <input
+                    id="slug"
+                    type="text"
+                    required
+                    value={draft.slug}
+                    onChange={(event) => updateField('slug', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="summary">Summary</label>
+                <textarea
+                  id="summary"
+                  rows={2}
+                  value={draft.summary}
+                  onChange={(event) => updateField('summary', event.target.value)}
+                />
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="description">Description</label>
+                <textarea
+                  id="description"
+                  rows={4}
+                  value={draft.description}
+                  onChange={(event) => updateField('description', event.target.value)}
+                />
+              </div>
+
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="location">Location</label>
+                  <input
+                    id="location"
+                    type="text"
+                    value={draft.location}
+                    onChange={(event) => updateField('location', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="hero">Hero image URL</label>
+                  <input
+                    id="hero"
+                    type="url"
+                    value={draft.hero_image_url}
+                    onChange={(event) => updateField('hero_image_url', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="starts_at">Starts at</label>
+                  <input
+                    id="starts_at"
+                    type="datetime-local"
+                    required
+                    value={draft.starts_at}
+                    onChange={(event) => updateField('starts_at', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="ends_at">Ends at</label>
+                  <input
+                    id="ends_at"
+                    type="datetime-local"
+                    value={draft.ends_at}
+                    onChange={(event) => updateField('ends_at', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  checked={draft.is_published}
+                  onChange={(event) => updateField('is_published', event.target.checked)}
+                />
+                <span>Published</span>
+              </label>
+
+              <div className="actions">
+                <button type="button" className="button secondary" onClick={closeModal} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="submit" className="button" disabled={saving}>
+                  {saving ? 'Saving…' : 'Save event'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/admin/layout.js
+++ b/apps/web/app/admin/layout.js
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { clearSession, getSession } from '../../lib/session';
+
+const NAV_ITEMS = [
+  { href: '/admin/events', label: 'Events' },
+  { href: '/admin/media', label: 'Media' },
+  { href: '/admin/links', label: 'Links' },
+  { href: '/admin/messages', label: 'Messages' },
+];
+
+export default function AdminLayout({ children }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const session = getSession();
+    if (!session) {
+      router.replace('/login');
+    } else {
+      setReady(true);
+    }
+  }, [router]);
+
+  function signOut() {
+    clearSession();
+    router.replace('/login');
+  }
+
+  if (!ready) {
+    return null;
+  }
+
+  return (
+    <div>
+      <nav className="admin-nav">
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <ul>
+            {NAV_ITEMS.map((item) => {
+              const isActive = pathname?.startsWith(item.href);
+              return (
+                <li key={item.href}>
+                  <Link href={item.href} className={isActive ? 'active' : undefined}>
+                    {item.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <div style={{ paddingRight: '1.5rem' }}>
+            <button className="button secondary" onClick={signOut}>
+              Sign out
+            </button>
+          </div>
+        </div>
+      </nav>
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/apps/web/app/admin/links/page.js
+++ b/apps/web/app/admin/links/page.js
@@ -1,0 +1,297 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { apiDelete, apiGet, apiPost } from '../../../lib/api';
+import { sortByOrder } from '../../../lib/utils';
+
+const CATEGORIES = [
+  { value: 'primary', label: 'Primary navigation' },
+  { value: 'secondary', label: 'Secondary navigation' },
+  { value: 'social', label: 'Social links' },
+];
+
+function createEmptyLink() {
+  return {
+    id: null,
+    label: '',
+    url: '',
+    category: 'primary',
+    order: 0,
+    is_active: true,
+  };
+}
+
+export default function LinksPage() {
+  const { data, error, isLoading, mutate } = useSWR('/links', () => apiGet('/links'));
+  const links = useMemo(() => data?.links ?? [], [data]);
+
+  const [showModal, setShowModal] = useState(false);
+  const [draft, setDraft] = useState(() => createEmptyLink());
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [reordering, setReordering] = useState(false);
+
+  function openCreate() {
+    setDraft(createEmptyLink());
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function openEdit(link) {
+    setDraft({ ...link });
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function closeModal() {
+    setShowModal(false);
+    setSaving(false);
+    setFormError('');
+  }
+
+  function updateField(field, value) {
+    setDraft((previous) => ({ ...previous, [field]: value }));
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSaving(true);
+    setFormError('');
+
+    const payload = {
+      id: draft.id ?? undefined,
+      label: draft.label,
+      url: draft.url,
+      category: draft.category,
+      order: Number(draft.order) || 0,
+      is_active: Boolean(draft.is_active),
+    };
+
+    try {
+      await apiPost('/links', payload);
+      await mutate();
+      closeModal();
+    } catch (err) {
+      setFormError(err.message || 'Failed to save link');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(link) {
+    if (!window.confirm(`Delete link "${link.label}"?`)) {
+      return;
+    }
+    try {
+      await apiDelete(`/links/${link.id}`);
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to delete link');
+    }
+  }
+
+  async function reorderLink(link, direction) {
+    const categoryLinks = sortByOrder(links.filter((item) => item.category === link.category));
+    const index = categoryLinks.findIndex((item) => item.id === link.id);
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= categoryLinks.length) {
+      return;
+    }
+    const swapped = [...categoryLinks];
+    const [removed] = swapped.splice(index, 1);
+    swapped.splice(targetIndex, 0, removed);
+
+    setReordering(true);
+    try {
+      await Promise.all(
+        swapped.map((item, position) =>
+          apiPost('/links', {
+            ...item,
+            order: position,
+          })
+        )
+      );
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to update order');
+    } finally {
+      setReordering(false);
+    }
+  }
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Navigation & Links</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Organise menu items and social links. Use the arrow buttons to reorder items within their group.
+          </p>
+        </div>
+        <button className="button" onClick={openCreate}>
+          New link
+        </button>
+      </header>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading links…</p>
+      ) : links.length === 0 ? (
+        <div className="empty-state">No links yet. Add your first navigation item.</div>
+      ) : (
+        <div className="stack">
+          {CATEGORIES.map((category) => {
+            const items = sortByOrder(links.filter((link) => link.category === category.value));
+            return (
+              <div key={category.value} className="card">
+                <header className="action-bar" style={{ marginBottom: '0.5rem' }}>
+                  <h2 style={{ margin: 0 }}>{category.label}</h2>
+                </header>
+                {items.length === 0 ? (
+                  <p style={{ margin: 0, color: '#666' }}>No links in this group.</p>
+                ) : (
+                  <div className="stack">
+                    {items.map((link) => (
+                      <div
+                        key={link.id}
+                        style={{
+                          display: 'grid',
+                          gridTemplateColumns: '1fr auto',
+                          gap: '1rem',
+                          alignItems: 'center',
+                          border: '1px solid #eee',
+                          borderRadius: '0.5rem',
+                          padding: '0.75rem 1rem',
+                          background: '#fff',
+                        }}
+                      >
+                        <div className="stack">
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                            <strong>{link.label}</strong>
+                            <span className="badge" style={{ background: link.is_active ? '#dcfce7' : '#fee2e2', color: link.is_active ? '#166534' : '#7f1d1d' }}>
+                              {link.is_active ? 'Active' : 'Hidden'}
+                            </span>
+                          </div>
+                          <a href={link.url} target="_blank" rel="noreferrer">
+                            {link.url}
+                          </a>
+                        </div>
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
+                          <button
+                            className="button secondary"
+                            onClick={() => reorderLink(link, 'up')}
+                            disabled={reordering}
+                          >
+                            ↑
+                          </button>
+                          <button
+                            className="button secondary"
+                            onClick={() => reorderLink(link, 'down')}
+                            disabled={reordering}
+                          >
+                            ↓
+                          </button>
+                          <button className="button secondary" onClick={() => openEdit(link)}>
+                            Edit
+                          </button>
+                          <button className="button" onClick={() => handleDelete(link)}>
+                            Delete
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showModal ? (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <div className="modal">
+            <header className="stack" style={{ marginBottom: '1rem' }}>
+              <h2 style={{ margin: 0 }}>{draft.id ? 'Edit link' : 'Add link'}</h2>
+              <p style={{ margin: 0, color: '#555' }}>
+                Choose the destination, placement, and visibility for this navigation item.
+              </p>
+            </header>
+            {formError ? <div className="alert">{formError}</div> : null}
+            <form className="stack" onSubmit={handleSubmit}>
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="link-label">Label</label>
+                  <input
+                    id="link-label"
+                    type="text"
+                    required
+                    value={draft.label}
+                    onChange={(event) => updateField('label', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="link-url">URL</label>
+                  <input
+                    id="link-url"
+                    type="url"
+                    required
+                    value={draft.url}
+                    onChange={(event) => updateField('url', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="link-category">Category</label>
+                  <select
+                    id="link-category"
+                    value={draft.category}
+                    onChange={(event) => updateField('category', event.target.value)}
+                  >
+                    {CATEGORIES.map((category) => (
+                      <option key={category.value} value={category.value}>
+                        {category.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="input-group">
+                  <label htmlFor="link-order">Order</label>
+                  <input
+                    id="link-order"
+                    type="number"
+                    min="0"
+                    value={draft.order}
+                    onChange={(event) => updateField('order', Number(event.target.value))}
+                  />
+                </div>
+              </div>
+
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  checked={draft.is_active}
+                  onChange={(event) => updateField('is_active', event.target.checked)}
+                />
+                <span>Visible</span>
+              </label>
+
+              <div className="actions">
+                <button type="button" className="button secondary" onClick={closeModal} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="submit" className="button" disabled={saving}>
+                  {saving ? 'Saving…' : 'Save link'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/admin/media/page.js
+++ b/apps/web/app/admin/media/page.js
@@ -1,0 +1,239 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import MetadataEditor from '../../../components/MetadataEditor';
+import { apiGet, apiPost } from '../../../lib/api';
+
+const MEDIA_TYPES = [
+  { type: 'gallery', label: 'Gallery' },
+  { type: 'testimonial', label: 'Testimonials' },
+  { type: 'partner', label: 'Partners' },
+];
+
+function createEmptyMedia(activeType) {
+  return {
+    id: null,
+    type: activeType,
+    title: '',
+    description: '',
+    asset_url: '',
+    metadata: {},
+  };
+}
+
+export default function MediaPage() {
+  const [activeType, setActiveType] = useState(MEDIA_TYPES[0].type);
+  const key = `/media/${activeType}`;
+  const { data, error, isLoading, mutate } = useSWR(key, () => apiGet(key));
+  const items = useMemo(() => data?.items ?? [], [data]);
+
+  const [showModal, setShowModal] = useState(false);
+  const [draft, setDraft] = useState(() => createEmptyMedia(activeType));
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  function changeType(type) {
+    setActiveType(type);
+    setShowModal(false);
+    setDraft(createEmptyMedia(type));
+    setFormError('');
+  }
+
+  function openCreate() {
+    setDraft(createEmptyMedia(activeType));
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function openEdit(item) {
+    setDraft({
+      id: item.id,
+      type: item.type,
+      title: item.title ?? '',
+      description: item.description ?? '',
+      asset_url: item.asset_url ?? '',
+      metadata: item.metadata ?? {},
+    });
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function closeModal() {
+    setShowModal(false);
+    setSaving(false);
+    setFormError('');
+  }
+
+  function updateField(field, value) {
+    setDraft((previous) => ({ ...previous, [field]: value }));
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSaving(true);
+    setFormError('');
+
+    const payload = {
+      id: draft.id ?? undefined,
+      type: draft.type,
+      title: draft.title || null,
+      description: draft.description || null,
+      asset_url: draft.asset_url,
+      metadata: Object.keys(draft.metadata || {}).length ? draft.metadata : null,
+    };
+
+    try {
+      await apiPost('/media', payload);
+      await mutate();
+      closeModal();
+    } catch (err) {
+      setFormError(err.message || 'Failed to save media item');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Media Library</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Upload links for gallery images, testimonials, and partner logos.
+          </p>
+        </div>
+        <button className="button" onClick={openCreate}>
+          New asset
+        </button>
+      </header>
+
+      <div className="tabs" role="tablist">
+        {MEDIA_TYPES.map((item) => (
+          <button
+            key={item.type}
+            type="button"
+            role="tab"
+            aria-selected={activeType === item.type}
+            className={`tab ${activeType === item.type ? 'active' : ''}`}
+            onClick={() => changeType(item.type)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading media…</p>
+      ) : items.length === 0 ? (
+        <div className="empty-state">No media yet. Add your first item.</div>
+      ) : (
+        <div className="list">
+          {items.map((item) => (
+            <div key={item.id} className="card">
+              <div className="stack">
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <h2 style={{ margin: 0 }}>{item.title || 'Untitled'}</h2>
+                    <p style={{ margin: '0.25rem 0', color: '#555' }}>{item.description || '—'}</p>
+                    <a href={item.asset_url} target="_blank" rel="noreferrer">
+                      {item.asset_url}
+                    </a>
+                  </div>
+                  <button className="button secondary" onClick={() => openEdit(item)}>
+                    Edit
+                  </button>
+                </div>
+                {item.metadata ? (
+                  <div style={{ fontSize: '0.85rem', color: '#555' }}>
+                    <strong>Metadata:</strong>{' '}
+                    {Object.entries(item.metadata).map(([key, value]) => (
+                      <span key={key} style={{ marginRight: '0.75rem' }}>
+                        {key}: {String(value)}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showModal ? (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <div className="modal">
+            <header className="stack" style={{ marginBottom: '1rem' }}>
+              <h2 style={{ margin: 0 }}>{draft.id ? 'Edit asset' : 'Add asset'}</h2>
+              <p style={{ margin: 0, color: '#555' }}>
+                Provide the public URL for the media and optional metadata (alt text, credits, etc.).
+              </p>
+            </header>
+            {formError ? <div className="alert">{formError}</div> : null}
+            <form className="stack" onSubmit={handleSubmit}>
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="media-title">Title</label>
+                  <input
+                    id="media-title"
+                    type="text"
+                    value={draft.title}
+                    onChange={(event) => updateField('title', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="media-type">Type</label>
+                  <select
+                    id="media-type"
+                    value={draft.type}
+                    onChange={(event) => updateField('type', event.target.value)}
+                  >
+                    {MEDIA_TYPES.map((option) => (
+                      <option key={option.type} value={option.type}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="media-description">Description</label>
+                <textarea
+                  id="media-description"
+                  rows={2}
+                  value={draft.description}
+                  onChange={(event) => updateField('description', event.target.value)}
+                />
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="media-url">Asset URL</label>
+                <input
+                  id="media-url"
+                  type="url"
+                  required
+                  value={draft.asset_url}
+                  onChange={(event) => updateField('asset_url', event.target.value)}
+                />
+              </div>
+
+              <MetadataEditor value={draft.metadata} onChange={(metadata) => updateField('metadata', metadata)} />
+
+              <div className="actions">
+                <button type="button" className="button secondary" onClick={closeModal} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="submit" className="button" disabled={saving}>
+                  {saving ? 'Saving…' : 'Save asset'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/admin/messages/page.js
+++ b/apps/web/app/admin/messages/page.js
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { apiGet } from '../../../lib/api';
+
+export default function MessagesPage() {
+  const { data, error, isLoading } = useSWR('/messaging', () => apiGet('/messaging'));
+  const messages = useMemo(() => data?.messages ?? [], [data]);
+  const [selectedId, setSelectedId] = useState(null);
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      setSelectedId(null);
+    } else if (!selectedId || !messages.find((message) => message.id === selectedId)) {
+      setSelectedId(messages[0].id);
+    }
+  }, [messages, selectedId]);
+
+  const active = messages.find((message) => message.id === selectedId) ?? null;
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Messages</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Incoming enquiries from the website contact form. Messages are read-only in Phase 1.
+          </p>
+        </div>
+      </header>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading messages…</p>
+      ) : messages.length === 0 ? (
+        <div className="empty-state">No messages yet. New enquiries will appear here.</div>
+      ) : (
+        <div className="message-list">
+          <div className="message-items" role="list">
+            {messages.map((message) => (
+              <button
+                key={message.id}
+                type="button"
+                role="listitem"
+                className={message.id === selectedId ? 'active' : undefined}
+                onClick={() => setSelectedId(message.id)}
+              >
+                <div style={{ fontWeight: 600 }}>{message.sender_name}</div>
+                <div style={{ fontSize: '0.85rem', color: '#555' }}>{message.sender_email}</div>
+                <div style={{ marginTop: '0.25rem', fontSize: '0.8rem', color: '#777' }}>
+                  {new Date(message.created_at).toLocaleString('en-US', { timeZone: 'Asia/Jakarta' })}
+                </div>
+              </button>
+            ))}
+          </div>
+          <div className="message-detail">
+            {active ? (
+              <div className="stack">
+                <div>
+                  <h2 style={{ margin: '0 0 0.25rem' }}>{active.subject || 'No subject'}</h2>
+                  <div style={{ color: '#555' }}>
+                    From <strong>{active.sender_name}</strong> ·{' '}
+                    <a href={`mailto:${active.sender_email}`}>{active.sender_email}</a>
+                  </div>
+                  <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: '#666' }}>
+                    Received {new Date(active.created_at).toLocaleString('en-US', { timeZone: 'Asia/Jakarta' })}
+                  </div>
+                </div>
+                <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{active.body}</div>
+              </div>
+            ) : (
+              <p style={{ margin: 0 }}>Select a message to read it.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/admin/page.js
+++ b/apps/web/app/admin/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminIndexPage() {
+  redirect('/admin/events');
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,259 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f5f5;
+  color: #1f1f1f;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+main {
+  padding: 1.5rem;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.table th {
+  background: #fafafa;
+}
+
+.action-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #b7001f;
+  color: #fff;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.button.secondary {
+  background: #555;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  background: #eee;
+  font-size: 0.75rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid.two-col {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.input-group label {
+  font-weight: 600;
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  background: #fff;
+}
+
+.tab.active {
+  background: #b7001f;
+  border-color: #b7001f;
+  color: #fff;
+}
+
+.list {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+}
+
+.stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+nav.admin-nav {
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+nav.admin-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  gap: 1.25rem;
+}
+
+nav.admin-nav a {
+  text-decoration: none;
+  color: #444;
+  font-weight: 600;
+}
+
+nav.admin-nav a.active {
+  color: #b7001f;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: #fee2e2;
+  color: #7f1d1d;
+  margin-bottom: 1rem;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  background: #fff;
+  border-radius: 0.75rem;
+  border: 1px dashed #ccc;
+}
+
+.metadata-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.metadata-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.metadata-row input {
+  width: 100%;
+}
+
+.metadata-row button {
+  justify-self: start;
+}
+
+.message-list {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 1rem;
+}
+
+.message-items {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.message-items button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem;
+  border: none;
+  background: transparent;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.message-items button.active {
+  background: #f0f0f0;
+}
+
+.message-detail {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+form .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}

--- a/apps/web/app/layout.js
+++ b/apps/web/app/layout.js
@@ -1,0 +1,16 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'KCI CMS',
+  description: 'Admin console for Komunitas Chinese Indonesia',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/login/page.js
+++ b/apps/web/app/login/page.js
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSession, getSession } from '../../lib/session';
+import { apiPost } from '../../lib/api';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const session = getSession();
+    if (session) {
+      router.replace('/admin');
+    }
+  }, [router]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const admin = await apiPost('/auth/login', { email, password });
+      createSession(admin);
+      router.replace('/admin');
+    } catch (err) {
+      setError(err.message || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main style={{ display: 'grid', placeItems: 'center', minHeight: '100vh' }}>
+      <div className="card" style={{ width: 'min(420px, 100%)' }}>
+        <div className="stack">
+          <header>
+            <h1 style={{ margin: 0 }}>KCI CMS Login</h1>
+            <p style={{ marginTop: '0.35rem', color: '#555' }}>
+              Enter your admin credentials to continue.
+            </p>
+          </header>
+          {error ? <div className="alert">{error}</div> : null}
+          <form className="stack" onSubmit={handleSubmit}>
+            <label className="stack">
+              <span>Email</span>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="admin@example.com"
+              />
+            </label>
+            <label className="stack">
+              <span>Password</span>
+              <input
+                type="password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+              />
+            </label>
+            <button className="button" type="submit" disabled={loading}>
+              {loading ? 'Signing in…' : 'Sign in'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function HomePage() {
+  redirect('/login');
+}

--- a/apps/web/components/MetadataEditor.js
+++ b/apps/web/components/MetadataEditor.js
@@ -1,0 +1,81 @@
+'use client';
+
+import { useMemo } from 'react';
+
+function toPairs(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return [];
+  }
+  return Object.entries(metadata).map(([key, value]) => ({ key, value }));
+}
+
+export default function MetadataEditor({ label = 'Metadata', value, onChange }) {
+  const pairs = useMemo(() => {
+    const current = toPairs(value);
+    if (current.length === 0) {
+      return [{ key: '', value: '' }];
+    }
+    return current;
+  }, [value]);
+
+  function updatePair(index, field, nextValue) {
+    const nextPairs = pairs.map((pair, idx) =>
+      idx === index ? { ...pair, [field]: nextValue } : pair
+    );
+    emit(nextPairs);
+  }
+
+  function addPair() {
+    emit([...pairs, { key: '', value: '' }]);
+  }
+
+  function removePair(index) {
+    const nextPairs = pairs.filter((_, idx) => idx !== index);
+    emit(nextPairs.length ? nextPairs : [{ key: '', value: '' }]);
+  }
+
+  function emit(pairsList) {
+    const filtered = pairsList.filter((pair) => pair.key.trim() !== '');
+    const nextMetadata = filtered.reduce((acc, pair) => {
+      acc[pair.key] = pair.value;
+      return acc;
+    }, {});
+    onChange(nextMetadata);
+  }
+
+  return (
+    <div className="stack">
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      <div className="metadata-grid">
+        {pairs.map((pair, index) => (
+          <div className="metadata-row" key={index}>
+            <input
+              type="text"
+              placeholder="Key"
+              value={pair.key}
+              onChange={(event) => updatePair(index, 'key', event.target.value)}
+            />
+            <input
+              type="text"
+              placeholder="Value"
+              value={pair.value}
+              onChange={(event) => updatePair(index, 'value', event.target.value)}
+            />
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => removePair(index)}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+      <div>
+        <button type="button" className="button" onClick={addPair}>
+          Add metadata
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/api.js
+++ b/apps/web/lib/api.js
@@ -1,0 +1,47 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '/api';
+
+async function request(path, options = {}) {
+  const url = `${API_BASE}${path}`;
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}),
+  };
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const errorBody = await response.json();
+      message = errorBody?.message || message;
+    } catch (err) {
+      // ignore parsing error
+    }
+    throw new Error(message || 'Request failed');
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+export function apiGet(path) {
+  return request(path, { method: 'GET' });
+}
+
+export function apiPost(path, body) {
+  return request(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function apiDelete(path) {
+  return request(path, { method: 'DELETE' });
+}

--- a/apps/web/lib/session.js
+++ b/apps/web/lib/session.js
@@ -1,0 +1,28 @@
+const STORAGE_KEY = 'kci_admin_session';
+
+export function getSession() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch (err) {
+    console.warn('Failed to read session', err);
+    return null;
+  }
+}
+
+export function createSession(admin) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(admin));
+}
+
+export function clearSession() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+}

--- a/apps/web/lib/utils.js
+++ b/apps/web/lib/utils.js
@@ -1,0 +1,34 @@
+export function toJakartaInputValue(isoString) {
+  if (!isoString) {
+    return '';
+  }
+  const date = new Date(isoString);
+  const jakartaString = date.toLocaleString('en-US', {
+    timeZone: 'Asia/Jakarta',
+    hour12: false,
+  });
+  const jakartaDate = new Date(jakartaString);
+
+  const pad = (value) => String(value).padStart(2, '0');
+  const year = jakartaDate.getFullYear();
+  const month = pad(jakartaDate.getMonth() + 1);
+  const day = pad(jakartaDate.getDate());
+  const hours = pad(jakartaDate.getHours());
+  const minutes = pad(jakartaDate.getMinutes());
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function fromJakartaInputValue(value) {
+  if (!value) {
+    return null;
+  }
+  const [date, time] = value.split('T');
+  const normalizedTime = time.length === 5 ? `${time}:00` : time;
+  const withOffset = `${date}T${normalizedTime}+07:00`;
+  return new Date(withOffset).toISOString();
+}
+
+export function sortByOrder(items = []) {
+  return [...items].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  images: { unoptimized: true },
+  basePath: '/cms',
+  assetPrefix: '/cms',
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "build:cms": "next build && next export -o out"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "swr": "2.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the Next.js App Router project under `apps/web` with static export configuration for `/cms`
- add client-side login/session handling plus guarded admin layout and navigation
- implement CRUD screens for events, media, links, and a read-only inbox using the existing Fastify API

## Testing
- `npm install` *(fails: registry access returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b10779f883289ac5fc72694440a3