### PR TITLE
Add CMS-powered marketing site and hydrate legacy homepage

### DIFF
--- a/apps/web/app/marketing.css
+++ b/apps/web/app/marketing.css
@@ -1,0 +1,533 @@
+:root {
+  --site-bg: #faf9f7;
+  --site-foreground: #231f20;
+  --site-muted: #f2efea;
+  --brand-primary: #9f1d20;
+  --brand-primary-dark: #7c0f18;
+  --brand-accent: #d99d2b;
+  --site-card-radius: 20px;
+  --site-card-shadow: 0 24px 48px rgba(15, 15, 15, 0.08);
+}
+
+.site {
+  padding: 0;
+  background: var(--site-bg);
+  color: var(--site-foreground);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.site a {
+  color: inherit;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(250, 249, 247, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.site-container {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem;
+}
+
+.site-brand {
+  display: grid;
+  gap: 0.1rem;
+  font-weight: 700;
+}
+
+.site-brand__title {
+  font-size: 1.4rem;
+  letter-spacing: 0.05em;
+}
+
+.site-brand__subtitle {
+  font-size: 0.9rem;
+  color: rgba(35, 31, 32, 0.72);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  font-weight: 600;
+}
+
+.site-nav a {
+  text-decoration: none;
+  padding: 0.25rem 0;
+}
+
+.site-nav__cta {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: var(--brand-primary);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(159, 29, 32, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-nav__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(159, 29, 32, 0.3);
+}
+
+.site-hero {
+  padding: 4.5rem 0 3.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.site-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(217, 157, 43, 0.35), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(159, 29, 32, 0.25), transparent 45%);
+  z-index: 0;
+}
+
+.site-hero__grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.site-hero__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.site-hero__subtitle {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: rgba(35, 31, 32, 0.78);
+}
+
+.site-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-hero__card {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  background: #fff;
+  border-radius: var(--site-card-radius);
+  padding: 1.75rem;
+  box-shadow: var(--site-card-shadow);
+}
+
+.site-hero__stat {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.site-hero__stat-number {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.site-hero__stat-label {
+  color: rgba(35, 31, 32, 0.65);
+}
+
+.site-section {
+  padding: 4.5rem 0;
+}
+
+.site-section--muted {
+  background: var(--site-muted);
+}
+
+.site-section__inner {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  padding: 0 1.25rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.site-section-heading {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 680px;
+}
+
+.site-section-heading h2 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin: 0;
+}
+
+.site-section-heading__description {
+  color: rgba(35, 31, 32, 0.74);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.site-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--brand-primary);
+}
+
+.site-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: var(--brand-primary);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 32px rgba(159, 29, 32, 0.2);
+}
+
+.site-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 38px rgba(159, 29, 32, 0.26);
+}
+
+.site-button--ghost {
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--brand-primary);
+  box-shadow: inset 0 0 0 1px rgba(159, 29, 32, 0.25);
+}
+
+.site-values-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.site-value-card {
+  background: #fff;
+  padding: 1.75rem;
+  border-radius: 18px;
+  box-shadow: var(--site-card-shadow);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.site-events-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.site-event-card {
+  background: #fff;
+  border-radius: var(--site-card-radius);
+  overflow: hidden;
+  box-shadow: var(--site-card-shadow);
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.site-event-card__media img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.site-event-card__body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.site-event-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: rgba(35, 31, 32, 0.65);
+}
+
+.site-event-card__date {
+  font-weight: 600;
+}
+
+.site-event-card__location {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.site-event-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.site-event-card__description {
+  margin: 0;
+  color: rgba(35, 31, 32, 0.72);
+  line-height: 1.6;
+}
+
+.site-event-card__link {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--brand-primary);
+}
+
+.site-status-message {
+  background: rgba(35, 31, 32, 0.04);
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  color: rgba(35, 31, 32, 0.75);
+}
+
+.site-status-message--error {
+  background: rgba(159, 29, 32, 0.08);
+  color: #7c0f18;
+}
+
+.site-testimonial-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.site-testimonial-card {
+  background: #fff;
+  border-radius: var(--site-card-radius);
+  box-shadow: var(--site-card-shadow);
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.75rem;
+}
+
+.site-testimonial-card__body {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.site-testimonial-card__avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 999px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.site-testimonial-card__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.site-testimonial-card__quote {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(35, 31, 32, 0.78);
+  margin: 0;
+}
+
+.site-testimonial-card__author {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.site-testimonial-card__name {
+  font-weight: 700;
+}
+
+.site-testimonial-card__role {
+  color: rgba(35, 31, 32, 0.6);
+  font-size: 0.9rem;
+}
+
+.site-partner-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.site-partner-card {
+  background: #fff;
+  border-radius: var(--site-card-radius);
+  padding: 1.5rem;
+  box-shadow: var(--site-card-shadow);
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+.site-partner-card__logo img {
+  width: 120px;
+  height: 120px;
+  object-fit: contain;
+  mix-blend-mode: multiply;
+}
+
+.site-partner-card__body h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.site-partner-card__body p {
+  margin: 0.5rem 0 0;
+  color: rgba(35, 31, 32, 0.68);
+}
+
+.site-contact {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.site-contact__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.site-contact__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.site-contact__label {
+  display: block;
+  font-weight: 600;
+  color: rgba(35, 31, 32, 0.65);
+}
+
+.site-contact__social {
+  margin-top: 1.75rem;
+  justify-content: flex-start;
+}
+
+.site-contact__card {
+  background: #fff;
+  border-radius: var(--site-card-radius);
+  padding: 2rem;
+  box-shadow: var(--site-card-shadow);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.site-social-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-social-link {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand-primary);
+  text-decoration: none;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-social-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.12);
+}
+
+.site-social-link svg {
+  width: 22px;
+  height: 22px;
+}
+
+.site-footer {
+  background: #111;
+  color: rgba(255, 255, 255, 0.82);
+  padding: 2.5rem 0;
+}
+
+.site-footer__grid {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: start;
+}
+
+.site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.site-footer__links a {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+}
+
+.site-footer__meta {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.site-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    position: static;
+  }
+
+  .site-container {
+    padding: 1.25rem 1rem;
+  }
+
+  .site-header .site-container {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .site-nav {
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+  }
+
+  .site-hero {
+    padding: 3.5rem 0 2.5rem;
+  }
+
+  .site-hero__card {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .site-values-grid,
+  .site-events-grid,
+  .site-testimonial-grid,
+  .site-partner-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,5 +1,162 @@
-import { redirect } from 'next/navigation';
+import './marketing.css';
+import { EventsSection } from '../components/public/EventsSection';
+import { TestimonialsSection } from '../components/public/TestimonialsSection';
+import { PartnersSection } from '../components/public/PartnersSection';
+import { SocialLinks } from '../components/public/SocialLinks';
+
+export const metadata = {
+  title: 'Komunitas Chinese Indonesia',
+  description:
+    'Komunitas Chinese Indonesia (KCI) menjadi wadah kolaborasi lintas generasi untuk melestarikan budaya Tionghoa-Indonesia dan berkontribusi bagi masyarakat.',
+};
 
 export default function HomePage() {
-  redirect('/login');
+  return (
+    <main className="site">
+      <header className="site-header">
+        <div className="site-container">
+          <div className="site-brand">
+            <span className="site-brand__title">KCI</span>
+            <span className="site-brand__subtitle">Komunitas Chinese Indonesia</span>
+          </div>
+          <nav className="site-nav">
+            <a href="#visi-misi">Visi Misi</a>
+            <a href="#acara">Acara</a>
+            <a href="#testimoni">Testimoni</a>
+            <a href="#hubungi">Kontak</a>
+            <a className="site-nav__cta" href="https://bit.ly/3TwZt9W" target="_blank" rel="noopener noreferrer">
+              Bergabung
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      <section className="site-hero" id="beranda">
+        <div className="site-container site-hero__grid">
+          <div className="site-hero__content">
+            <p className="site-eyebrow">Unity in Diversity</p>
+            <h1>Komunitas Chinese Indonesia</h1>
+            <p className="site-hero__subtitle">
+              Ruang kolaborasi lintas generasi untuk berkarya, melestarikan budaya, dan berdampak bagi masyarakat.
+            </p>
+            <div className="site-hero__actions">
+              <a
+                className="site-button"
+                href="https://docs.google.com/forms/d/e/1FAIpQLSfVtN0rFgoPdWteWijMsZWXXyFtaxdJvavjaPNhC4OZ5kBDeg/viewform"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Daftar Anggota
+              </a>
+              <a className="site-button site-button--ghost" href="#acara">
+                Lihat Kegiatan
+              </a>
+            </div>
+          </div>
+          <div className="site-hero__card">
+            <div className="site-hero__stat">
+              <span className="site-hero__stat-number">50+</span>
+              <span className="site-hero__stat-label">Relawan aktif</span>
+            </div>
+            <div className="site-hero__stat">
+              <span className="site-hero__stat-number">12</span>
+              <span className="site-hero__stat-label">Kegiatan bulanan</span>
+            </div>
+            <div className="site-hero__stat">
+              <span className="site-hero__stat-number">8</span>
+              <span className="site-hero__stat-label">Kota kolaborasi</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="site-section site-section--muted" id="visi-misi">
+        <div className="site-section__inner">
+          <div className="site-section-heading">
+            <p className="site-eyebrow">Arah Gerak Komunitas</p>
+            <h2>Visi &amp; Misi</h2>
+            <p className="site-section-heading__description">
+              Membangun komunitas yang harmonis, inklusif, dan berdampak melalui pelestarian budaya, kolaborasi, dan pelayanan.
+            </p>
+          </div>
+          <div className="site-values-grid">
+            <article className="site-value-card">
+              <h3>Pelestarian Budaya</h3>
+              <p>Merawat identitas Tionghoa-Indonesia melalui seni, tradisi, dan perayaan komunitas.</p>
+            </article>
+            <article className="site-value-card">
+              <h3>Pemberdayaan Sosial</h3>
+              <p>Berjejaring dengan komunitas dan lembaga sosial untuk menghadirkan program kemanusiaan.</p>
+            </article>
+            <article className="site-value-card">
+              <h3>Pengembangan Generasi Muda</h3>
+              <p>Menyediakan ruang belajar, kepemimpinan, dan kewirausahaan bagi generasi penerus.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <EventsSection />
+      <TestimonialsSection />
+      <PartnersSection />
+
+      <section className="site-section" id="hubungi">
+        <div className="site-section__inner site-contact">
+          <div className="site-contact__content">
+            <div className="site-section-heading">
+              <p className="site-eyebrow">Terhubung dengan KCI</p>
+              <h2>Hubungi Kami</h2>
+              <p className="site-section-heading__description">
+                Kami terbuka untuk kolaborasi komunitas, kemitraan bisnis, dan dukungan program sosial.
+              </p>
+            </div>
+            <ul className="site-contact__list">
+              <li>
+                <span className="site-contact__label">Founder</span>
+                <a href="https://wa.me/6287884924385" target="_blank" rel="noopener noreferrer">
+                  +62 878-8492-4385
+                </a>
+              </li>
+              <li>
+                <span className="site-contact__label">Admin</span>
+                <a href="https://wa.me/6285641877775" target="_blank" rel="noopener noreferrer">
+                  +62 856-4187-7775
+                </a>
+              </li>
+              <li>
+                <span className="site-contact__label">Email</span>
+                <a href="mailto:hello@kci.or.id">hello@kci.or.id</a>
+              </li>
+            </ul>
+            <SocialLinks className="site-contact__social" />
+          </div>
+          <div className="site-contact__card">
+            <h3>Siap Berkontribusi?</h3>
+            <p>
+              Daftar sebagai relawan atau mitra program dan dapatkan pembaruan kegiatan langsung ke email Anda.
+            </p>
+            <a className="site-button" href="https://bit.ly/3TwZt9W" target="_blank" rel="noopener noreferrer">
+              Isi formulir bergabung
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <footer className="site-footer">
+        <div className="site-container site-footer__grid">
+          <div>
+            <p className="site-brand__title">KCI</p>
+            <p className="site-brand__subtitle">Komunitas Chinese Indonesia</p>
+          </div>
+          <div className="site-footer__links">
+            <a href="#visi-misi">Visi Misi</a>
+            <a href="#acara">Acara</a>
+            <a href="#testimoni">Testimoni</a>
+            <a href="#hubungi">Kontak</a>
+          </div>
+          <p className="site-footer__meta">&copy; {new Date().getFullYear()} Komunitas Chinese Indonesia. Semua hak dilindungi.</p>
+        </div>
+      </footer>
+    </main>
+  );
 }

--- a/apps/web/components/public/EventsSection.js
+++ b/apps/web/components/public/EventsSection.js
@@ -1,0 +1,99 @@
+'use client';
+
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+const DATE_FORMAT_OPTIONS = { dateStyle: 'long', timeZone: 'Asia/Jakarta' };
+const TIME_FORMAT_OPTIONS = { timeStyle: 'short', timeZone: 'Asia/Jakarta' };
+const DATE_TIME_OPTIONS = { dateStyle: 'long', timeStyle: 'short', timeZone: 'Asia/Jakarta' };
+
+function getJakartaDateKey(isoString) {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jakarta' }).format(new Date(isoString));
+}
+
+function formatDateRange(startsAt, endsAt) {
+  if (!startsAt) {
+    return '';
+  }
+
+  const startDate = new Date(startsAt);
+  if (!endsAt) {
+    return new Intl.DateTimeFormat('id-ID', DATE_TIME_OPTIONS).format(startDate);
+  }
+
+  const endDate = new Date(endsAt);
+  const startKey = getJakartaDateKey(startsAt);
+  const endKey = getJakartaDateKey(endsAt);
+
+  if (startKey === endKey) {
+    const dateLabel = new Intl.DateTimeFormat('id-ID', DATE_FORMAT_OPTIONS).format(startDate);
+    const startTime = new Intl.DateTimeFormat('id-ID', TIME_FORMAT_OPTIONS).format(startDate);
+    const endTime = new Intl.DateTimeFormat('id-ID', TIME_FORMAT_OPTIONS).format(endDate);
+    return `${dateLabel} • ${startTime} – ${endTime} WIB`;
+  }
+
+  const formatter = new Intl.DateTimeFormat('id-ID', DATE_TIME_OPTIONS);
+  return `${formatter.format(startDate)} – ${formatter.format(endDate)}`;
+}
+
+function EventCard({ event }) {
+  const description = event.summary || event.description || '';
+  const dateLabel = formatDateRange(event.starts_at, event.ends_at);
+
+  return (
+    <article className="site-event-card">
+      {event.hero_image_url ? (
+        <div className="site-event-card__media">
+          <img src={event.hero_image_url} alt={event.title} loading="lazy" />
+        </div>
+      ) : null}
+      <div className="site-event-card__body">
+        <div className="site-event-card__meta">
+          {dateLabel ? <span className="site-event-card__date">{dateLabel}</span> : null}
+          {event.location ? <span className="site-event-card__location">{event.location}</span> : null}
+        </div>
+        <h3 className="site-event-card__title">{event.title}</h3>
+        {description ? <p className="site-event-card__description">{description}</p> : null}
+        <a className="site-event-card__link" href={`#/acara/${event.slug}`}>Detail acara</a>
+      </div>
+    </article>
+  );
+}
+
+export function EventsSection() {
+  const { data, error, isLoading } = useSWR('/events', () => apiGet('/events'));
+  const events = data?.events ?? [];
+
+  let content = null;
+
+  if (error) {
+    content = <p className="site-status-message site-status-message--error">Gagal memuat acara. Silakan coba lagi.</p>;
+  } else if (isLoading) {
+    content = <p className="site-status-message">Memuat jadwal acara…</p>;
+  } else if (events.length === 0) {
+    content = <p className="site-status-message">Belum ada acara yang dipublikasikan.</p>;
+  } else {
+    content = (
+      <div className="site-events-grid">
+        {events.map((event) => (
+          <EventCard key={event.id} event={event} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <section className="site-section" id="acara">
+      <div className="site-section__inner">
+        <div className="site-section-heading">
+          <p className="site-eyebrow">Agenda Terbaru</p>
+          <h2>Acara &amp; Kegiatan</h2>
+          <p className="site-section-heading__description">
+            Kegiatan komunitas yang memperkuat jejaring, budaya, dan kontribusi sosial KCI.
+          </p>
+        </div>
+        {content}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/public/PartnersSection.js
+++ b/apps/web/components/public/PartnersSection.js
@@ -1,0 +1,59 @@
+'use client';
+
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+function PartnerCard({ partner }) {
+  const altText = partner.metadata?.alt || partner.title || 'Partner KCI';
+
+  return (
+    <article className="site-partner-card">
+      {partner.asset_url ? (
+        <div className="site-partner-card__logo">
+          <img src={partner.asset_url} alt={altText} loading="lazy" />
+        </div>
+      ) : null}
+      <div className="site-partner-card__body">
+        <h3>{partner.title || 'Partner KCI'}</h3>
+        {partner.description ? <p>{partner.description}</p> : null}
+      </div>
+    </article>
+  );
+}
+
+export function PartnersSection() {
+  const { data, error, isLoading } = useSWR('/media/partner', () => apiGet('/media/partner'));
+  const partners = data?.items ?? [];
+
+  let content = null;
+  if (error) {
+    content = <p className="site-status-message site-status-message--error">Tidak dapat memuat daftar mitra.</p>;
+  } else if (isLoading) {
+    content = <p className="site-status-message">Memuat mitra komunitas…</p>;
+  } else if (partners.length === 0) {
+    content = <p className="site-status-message">Belum ada mitra yang terdaftar.</p>;
+  } else {
+    content = (
+      <div className="site-partner-grid">
+        {partners.map((partner) => (
+          <PartnerCard key={partner.id} partner={partner} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <section className="site-section" id="mitra">
+      <div className="site-section__inner">
+        <div className="site-section-heading">
+          <p className="site-eyebrow">Kolaborasi</p>
+          <h2>Mitra &amp; Pendukung</h2>
+          <p className="site-section-heading__description">
+            Dukungan dari organisasi dan komunitas yang bergerak bersama mewujudkan visi KCI.
+          </p>
+        </div>
+        {content}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/public/SocialLinks.js
+++ b/apps/web/components/public/SocialLinks.js
@@ -1,0 +1,78 @@
+'use client';
+
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+const ICONS = {
+  instagram: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <rect x="2" y="2" width="20" height="20" rx="5" ry="5" fill="none" stroke="currentColor" strokeWidth="2" />
+      <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" fill="none" stroke="currentColor" strokeWidth="2" />
+      <circle cx="17.5" cy="6.5" r="1.5" fill="currentColor" />
+    </svg>
+  ),
+  tiktok: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12.5 0h3.1c.21 1.79 1.39 3.4 3 4.35 1.02.6 2.17.93 3.4.93V8c-1.9 0-3.72-.55-5.23-1.6v8.33A7.73 7.73 0 1 1 9.38 8.3V11.5a4.48 4.48 0 1 0 3.12 4.2V0z"
+      />
+    </svg>
+  ),
+  youtube: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M21.6 6.2a2.7 2.7 0 0 0-1.9-1.9C17.8 4 12 4 12 4s-5.8 0-7.7.3A2.7 2.7 0 0 0 2.4 6.2 28.9 28.9 0 0 0 2 12a28.9 28.9 0 0 0 .4 5.8 2.7 2.7 0 0 0 1.9 1.9C6.2 19.9 12 19.9 12 19.9s5.8 0 7.7-.3a2.7 2.7 0 0 0 1.9-1.9 28.9 28.9 0 0 0 .4-5.8 28.9 28.9 0 0 0-.4-5.7zM10 15.5v-7l6 3.5-6 3.5z"
+      />
+    </svg>
+  ),
+  facebook: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M14 9h3V6h-3c-2.2 0-4 1.8-4 4v2H7v3h3v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z"
+      />
+    </svg>
+  ),
+};
+
+function getIcon(url) {
+  const lower = url.toLowerCase();
+  if (lower.includes('instagram')) return ICONS.instagram;
+  if (lower.includes('tiktok')) return ICONS.tiktok;
+  if (lower.includes('youtube')) return ICONS.youtube;
+  if (lower.includes('facebook')) return ICONS.facebook;
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 14.5h-2V11h2zm0-6h-2V8h2z"
+      />
+    </svg>
+  );
+}
+
+export function SocialLinks({ className = '' }) {
+  const { data, error, isLoading } = useSWR('/links', () => apiGet('/links'));
+  const links = (data?.links || []).filter((link) => link.category === 'social' && link.is_active);
+
+  if (error || isLoading) {
+    return null;
+  }
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`site-social-links ${className}`.trim()}>
+      {links.map((link) => (
+        <a key={link.id} className="site-social-link" href={link.url} target="_blank" rel="noopener noreferrer">
+          {getIcon(link.url)}
+          <span className="site-sr-only">{link.label}</span>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/public/TestimonialsSection.js
+++ b/apps/web/components/public/TestimonialsSection.js
@@ -1,0 +1,64 @@
+'use client';
+
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+function TestimonialCard({ item }) {
+  const description = item.description || '';
+  const title = item.title || 'Anggota Komunitas';
+  const role = item.metadata?.role || item.metadata?.subtitle || '';
+
+  return (
+    <article className="site-testimonial-card">
+      {item.asset_url ? (
+        <div className="site-testimonial-card__avatar">
+          <img src={item.asset_url} alt={title} loading="lazy" />
+        </div>
+      ) : null}
+      <div className="site-testimonial-card__body">
+        <p className="site-testimonial-card__quote">“{description || 'Terima kasih telah menjadi bagian dari KCI.'}”</p>
+        <div className="site-testimonial-card__author">
+          <span className="site-testimonial-card__name">{title}</span>
+          {role ? <span className="site-testimonial-card__role">{role}</span> : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function TestimonialsSection() {
+  const { data, error, isLoading } = useSWR('/media/testimonial', () => apiGet('/media/testimonial'));
+  const testimonials = data?.items ?? [];
+
+  let content = null;
+  if (error) {
+    content = <p className="site-status-message site-status-message--error">Gagal memuat testimoni.</p>;
+  } else if (isLoading) {
+    content = <p className="site-status-message">Mengambil cerita anggota…</p>;
+  } else if (testimonials.length === 0) {
+    content = <p className="site-status-message">Belum ada testimoni yang ditampilkan.</p>;
+  } else {
+    content = (
+      <div className="site-testimonial-grid">
+        {testimonials.map((item) => (
+          <TestimonialCard key={item.id} item={item} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <section className="site-section site-section--muted" id="testimoni">
+      <div className="site-section__inner">
+        <div className="site-section-heading">
+          <p className="site-eyebrow">Cerita Anggota</p>
+          <h2>Testimoni Komunitas</h2>
+          <p className="site-section-heading__description">
+            Pengalaman para anggota dalam berkegiatan dan bertumbuh bersama Komunitas Chinese Indonesia.
+          </p>
+        </div>
+        {content}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,8 +2,6 @@
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
-  basePath: '/cms',
-  assetPrefix: '/cms',
 };
 
 module.exports = nextConfig;

--- a/legacy/php/index.html
+++ b/legacy/php/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="id">
+<html lang="id" data-api-base="/api">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -98,10 +98,12 @@
                 <p class="section-subtitle">Berbagai kegiatan komunitas yang mempererat persaudaraan</p>
             </div>
 
-            <div class="events-placeholder">
+            <div class="dynamic-grid" data-events-list hidden></div>
+            <div class="dynamic-placeholder" data-events-empty>
                 <p>Acara dan kegiatan akan segera diperbarui</p>
                 <p>Pantau terus perkembangan terbaru dari komunitas kami</p>
             </div>
+            <div class="dynamic-error" data-events-error hidden></div>
         </div>
     </section>
 
@@ -136,10 +138,12 @@
                 <p class="section-subtitle">Cerita dan pengalaman dari anggota komunitas kami</p>
             </div>
 
-            <div class="testimonials-placeholder">
+            <div class="dynamic-grid dynamic-grid--testimonials" data-testimonials-list hidden></div>
+            <div class="dynamic-placeholder" data-testimonials-empty>
                 <p>Testimoni dari anggota akan segera ditampilkan</p>
                 <p>Bagikan pengalaman Anda bersama KCI</p>
             </div>
+            <div class="dynamic-error" data-testimonials-error hidden></div>
         </div>
     </section>
 
@@ -203,7 +207,7 @@
     <div class="social-container" style="text-align:center;margin-top:24px;">
       <h3 style="color: var(--black); margin-bottom: 10px;">Media Sosial</h3>
       <p style="color: var(--gray);">Ikuti perkembangan terbaru dari komunitas kami</p>
-      <div class="social-links">
+      <div class="social-links" data-social-links>
         <!-- Instagram -->
         <a
           href="https://instagram.com/komunitaschineseindonesia"
@@ -229,6 +233,7 @@
           </svg>
         </a>
       </div>
+      <div class="dynamic-error dynamic-error--inline" data-social-error hidden></div>
     </div>
   </div>
 </section>
@@ -242,108 +247,12 @@
                 <p class="section-subtitle">Terima kasih kepada mitra yang mendukung komunitas kami</p>
             </div>
 
-            <!-- Business Partners -->
-            <div class="sponsor-section">
-                <h3 class="sponsor-category-title">📚 Business Partners</h3>
-                <div class="sponsor-carousel-container">
-                    <button class="carousel-btn carousel-btn-left" id="businessLeft">‹</button>
-                    <div class="sponsor-carousel" id="businessCarousel">
-                        <div class="sponsor-track">
-                            <a class="sponsor-card" href="https://www.instagram.com/kencana_property112" target="_blank" rel="noopener noreferrer">
-                                <div class="sponsor-logo">
-                                    <img src="/assets/partners/business/kencanaproperty.jpg" alt="Kencana Property" loading="lazy">
-                                </div>
-                                <h4 class="sponsor-name">KENCANA PROPERTY</h4>
-                            </a>
-
-                            <a class="sponsor-card" href="https://www.instagram.com/marketphone70" target="_blank" rel="noopener noreferrer">
-                                <div class="sponsor-logo">
-                                    <img src="/assets/partners/business/marketphone.jpg" alt="Market Phone" loading="lazy">
-                                </div>
-                                <h4 class="sponsor-name">MARKET PHONE</h4>
-                            </a>
-
-                            <div class="sponsor-card">
-                                <div class="sponsor-logo">
-                                    <img src="/assets/partners/business/accumart.jpg" alt="Accumart Jogja" loading="lazy">
-                                </div>
-                                <h4 class="sponsor-name">ACCUMART JOGJA</h4>
-                            </div>
-
-                            <a class="sponsor-card" href="https://www.instagram.com/basreng_domini" target="_blank" rel="noopener noreferrer">
-                                <div class="sponsor-logo">
-                                    <img src="/assets/partners/business/basrengdomini.jpg" alt="Basreng Domini" loading="lazy">
-                                </div>
-                                <h4 class="sponsor-name">BASRENG DOMINI</h4>
-                            </a>
-
-                            <!-- Placeholder cards for future sponsors -->
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-                        </div>
-                    </div>
-                    <button class="carousel-btn carousel-btn-right" id="businessRight">›</button>
-                </div>
+            <div class="dynamic-grid dynamic-grid--partners" data-partners-list hidden></div>
+            <div class="dynamic-placeholder" data-partners-empty>
+                <p>Daftar mitra akan segera diperbarui.</p>
+                <p>Hubungi kami untuk berkolaborasi dengan KCI.</p>
             </div>
-
-            <!-- Community Partners -->
-            <div class="sponsor-section">
-                <h3 class="sponsor-category-title">🤝 Community Partners</h3>
-                <div class="sponsor-carousel-container">
-                    <button class="carousel-btn carousel-btn-left" id="communityLeft">‹</button>
-                    <div class="sponsor-carousel" id="communityCarousel">
-                        <div class="sponsor-track">
-                            <a class="sponsor-card" href="https://www.instagram.com/komunitasberbagiyogyakarta" target="_blank" rel="noopener noreferrer">
-                                <div class="sponsor-logo">
-                                    <img src="/assets/partners/community/komunitasberbagiyogyakarta.jpg" alt="Komunitas Berbagi Yogyakarta" loading="lazy">
-                                </div>
-                                <h4 class="sponsor-name">KOMUNITAS BERBAGI YOGYAKARTA</h4>
-                            </a>
-
-                            <!-- Placeholder cards for future community partners -->
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-
-                            <div class="sponsor-card placeholder">
-                                <div class="sponsor-logo">
-                                    <span class="placeholder-icon">+</span>
-                                </div>
-                                <h4 class="sponsor-name muted">Coming Soon</h4>
-                            </div>
-                        </div>
-                    </div>
-                    <button class="carousel-btn carousel-btn-right" id="communityRight">›</button>
-                </div>
-            </div>
+            <div class="dynamic-error" data-partners-error hidden></div>
         </div>
     </section>
 

--- a/legacy/php/script.js
+++ b/legacy/php/script.js
@@ -6,6 +6,7 @@ const navMenu = document.getElementById('navMenu');
 const navLinks = document.querySelectorAll('.nav-link');
 const scrollTop = document.getElementById('scrollTop');
 const themeToggle = document.getElementById('themeToggle');
+const apiBase = document.documentElement.getAttribute('data-api-base') || '/api';
 
 // Hide loader when page loads
 if (loader) {
@@ -198,7 +199,7 @@ if (communityCarousel && communityLeftBtn && communityRightBtn) {
     // Update button visibility based on scroll position
     const updateCommunityButtons = () => {
         const maxScroll = communityCarousel.scrollWidth - communityCarousel.clientWidth;
-        
+
         if (communityCarousel.scrollLeft <= 0) {
             communityLeftBtn.style.opacity = '0.5';
             communityLeftBtn.style.cursor = 'not-allowed';
@@ -206,7 +207,7 @@ if (communityCarousel && communityLeftBtn && communityRightBtn) {
             communityLeftBtn.style.opacity = '1';
             communityLeftBtn.style.cursor = 'pointer';
         }
-        
+
         if (communityCarousel.scrollLeft >= maxScroll - 5) {
             communityRightBtn.style.opacity = '0.5';
             communityRightBtn.style.cursor = 'not-allowed';
@@ -220,6 +221,327 @@ if (communityCarousel && communityLeftBtn && communityRightBtn) {
     window.addEventListener('resize', updateCommunityButtons);
     updateCommunityButtons();
 }
+
+// ===== CMS DATA RENDERING =====
+
+const jakartaDateFormatter = new Intl.DateTimeFormat('id-ID', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+    timeZone: 'Asia/Jakarta'
+});
+const jakartaDayFormatter = new Intl.DateTimeFormat('id-ID', {
+    dateStyle: 'long',
+    timeZone: 'Asia/Jakarta'
+});
+const jakartaTimeFormatter = new Intl.DateTimeFormat('id-ID', {
+    timeStyle: 'short',
+    timeZone: 'Asia/Jakarta'
+});
+const jakartaKeyFormatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Jakarta'
+});
+
+function fetchJson(path) {
+    return fetch(`${apiBase}${path}`, {
+        headers: {
+            'Accept': 'application/json'
+        }
+    }).then(response => {
+        if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+        }
+        return response.json();
+    });
+}
+
+function setHidden(element, hidden) {
+    if (!element) return;
+    if (hidden) {
+        element.setAttribute('hidden', '');
+    } else {
+        element.removeAttribute('hidden');
+    }
+}
+
+function createElement(tag, className, text) {
+    const element = document.createElement(tag);
+    if (className) {
+        element.className = className;
+    }
+    if (typeof text === 'string' && text.length > 0) {
+        element.textContent = text;
+    }
+    return element;
+}
+
+function formatEventDateRange(startsAt, endsAt) {
+    if (!startsAt) return '';
+    const startDate = new Date(startsAt);
+    if (!endsAt) {
+        return jakartaDateFormatter.format(startDate);
+    }
+    const endDate = new Date(endsAt);
+    const startKey = jakartaKeyFormatter.format(startDate);
+    const endKey = jakartaKeyFormatter.format(endDate);
+
+    if (startKey === endKey) {
+        const dateLabel = jakartaDayFormatter.format(startDate);
+        const startTime = jakartaTimeFormatter.format(startDate);
+        const endTime = jakartaTimeFormatter.format(endDate);
+        return `${dateLabel} • ${startTime} - ${endTime} WIB`;
+    }
+
+    return `${jakartaDateFormatter.format(startDate)} - ${jakartaDateFormatter.format(endDate)}`;
+}
+
+function buildEventCard(event) {
+    const card = createElement('article', 'dynamic-card dynamic-card--event');
+
+    if (event.hero_image_url) {
+        const media = createElement('div', 'dynamic-card__media');
+        const img = document.createElement('img');
+        img.src = event.hero_image_url;
+        img.alt = event.title || 'Acara KCI';
+        img.loading = 'lazy';
+        media.appendChild(img);
+        card.appendChild(media);
+    }
+
+    const body = createElement('div', 'dynamic-card__body');
+    const meta = createElement('div', 'dynamic-card__meta');
+    const dateLabel = formatEventDateRange(event.starts_at, event.ends_at);
+    if (dateLabel) {
+        meta.appendChild(createElement('span', 'dynamic-card__date', dateLabel));
+    }
+    if (event.location) {
+        meta.appendChild(createElement('span', 'dynamic-card__location', event.location));
+    }
+    if (meta.childElementCount > 0) {
+        body.appendChild(meta);
+    }
+
+    body.appendChild(createElement('h3', 'dynamic-card__title', event.title || 'Acara Komunitas'));
+    if (event.summary || event.description) {
+        body.appendChild(createElement('p', 'dynamic-card__text', event.summary || event.description));
+    }
+
+    const cta = createElement('a', 'dynamic-card__link', 'Detail acara');
+    cta.href = `#/acara/${event.slug || ''}`;
+    body.appendChild(cta);
+
+    card.appendChild(body);
+    return card;
+}
+
+function buildTestimonialCard(item) {
+    const card = createElement('article', 'dynamic-card dynamic-card--testimonial');
+
+    if (item.asset_url) {
+        const avatar = createElement('div', 'dynamic-card__avatar');
+        const img = document.createElement('img');
+        img.src = item.asset_url;
+        img.alt = item.title || 'Anggota KCI';
+        img.loading = 'lazy';
+        avatar.appendChild(img);
+        card.appendChild(avatar);
+    }
+
+    const body = createElement('div', 'dynamic-card__body');
+    const quoteText = item.description || 'Terima kasih telah menjadi bagian dari Komunitas Chinese Indonesia.';
+    body.appendChild(createElement('p', 'dynamic-card__quote', `“${quoteText}”`));
+
+    const author = createElement('div', 'dynamic-card__author');
+    author.appendChild(createElement('span', 'dynamic-card__name', item.title || 'Anggota Komunitas'));
+    const testimonialMeta = item.metadata || {};
+    if (testimonialMeta.role || testimonialMeta.subtitle) {
+        author.appendChild(createElement('span', 'dynamic-card__meta', testimonialMeta.role || testimonialMeta.subtitle));
+    }
+    body.appendChild(author);
+
+    card.appendChild(body);
+    return card;
+}
+
+function buildPartnerCard(partner) {
+    const card = createElement('article', 'dynamic-card dynamic-card--partner');
+
+    if (partner.asset_url) {
+        const logo = createElement('div', 'dynamic-card__media');
+        const img = document.createElement('img');
+        img.src = partner.asset_url;
+        const partnerMeta = partner.metadata || {};
+        img.alt = partnerMeta.alt || partner.title || 'Partner KCI';
+        img.loading = 'lazy';
+        logo.appendChild(img);
+        card.appendChild(logo);
+    }
+
+    const body = createElement('div', 'dynamic-card__body');
+    body.appendChild(createElement('h3', 'dynamic-card__title', partner.title || 'Partner KCI'));
+    if (partner.description) {
+        body.appendChild(createElement('p', 'dynamic-card__text', partner.description));
+    }
+    card.appendChild(body);
+
+    return card;
+}
+
+function loadEvents() {
+    const list = document.querySelector('[data-events-list]');
+    if (!list) return;
+    const empty = document.querySelector('[data-events-empty]');
+    const errorBox = document.querySelector('[data-events-error]');
+
+    fetchJson('/events')
+        .then(data => {
+            setHidden(errorBox, true);
+            list.innerHTML = '';
+            const events = data && Array.isArray(data.events) ? data.events : [];
+            if (events.length === 0) {
+                setHidden(list, true);
+                setHidden(empty, false);
+                return;
+            }
+
+            events.forEach(eventItem => {
+                list.appendChild(buildEventCard(eventItem));
+            });
+            setHidden(list, false);
+            setHidden(empty, true);
+        })
+        .catch(() => {
+            setHidden(list, true);
+            setHidden(empty, true);
+            if (errorBox) {
+                errorBox.textContent = 'Gagal memuat data acara.';
+                setHidden(errorBox, false);
+            }
+        });
+}
+
+function loadTestimonials() {
+    const list = document.querySelector('[data-testimonials-list]');
+    if (!list) return;
+    const empty = document.querySelector('[data-testimonials-empty]');
+    const errorBox = document.querySelector('[data-testimonials-error]');
+
+    fetchJson('/media/testimonial')
+        .then(data => {
+            setHidden(errorBox, true);
+            list.innerHTML = '';
+            const items = data && Array.isArray(data.items) ? data.items : [];
+            if (items.length === 0) {
+                setHidden(list, true);
+                setHidden(empty, false);
+                return;
+            }
+
+            items.forEach(item => {
+                list.appendChild(buildTestimonialCard(item));
+            });
+            setHidden(list, false);
+            setHidden(empty, true);
+        })
+        .catch(() => {
+            setHidden(list, true);
+            setHidden(empty, true);
+            if (errorBox) {
+                errorBox.textContent = 'Gagal memuat testimoni.';
+                setHidden(errorBox, false);
+            }
+        });
+}
+
+function loadPartners() {
+    const list = document.querySelector('[data-partners-list]');
+    if (!list) return;
+    const empty = document.querySelector('[data-partners-empty]');
+    const errorBox = document.querySelector('[data-partners-error]');
+
+    fetchJson('/media/partner')
+        .then(data => {
+            setHidden(errorBox, true);
+            list.innerHTML = '';
+            const items = data && Array.isArray(data.items) ? data.items : [];
+            if (items.length === 0) {
+                setHidden(list, true);
+                setHidden(empty, false);
+                return;
+            }
+
+            items.forEach(partner => {
+                list.appendChild(buildPartnerCard(partner));
+            });
+            setHidden(list, false);
+            setHidden(empty, true);
+        })
+        .catch(() => {
+            setHidden(list, true);
+            setHidden(empty, true);
+            if (errorBox) {
+                errorBox.textContent = 'Gagal memuat mitra.';
+                setHidden(errorBox, false);
+            }
+        });
+}
+
+function getSocialIconMarkup(url) {
+    const lower = url.toLowerCase();
+    if (lower.includes('instagram')) {
+        return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="2" y="2" width="20" height="20" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" fill="none" stroke="currentColor" stroke-width="2"></path><circle cx="17.5" cy="6.5" r="1.5" fill="currentColor"></circle></svg>';
+    }
+    if (lower.includes('tiktok')) {
+        return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12.5 0h3.1c.21 1.79 1.39 3.4 3 4.35 1.02.6 2.17.93 3.4.93V8c-1.9 0-3.72-.55-5.23-1.6v8.33A7.73 7.73 0 1 1 9.38 8.3V11.5a4.48 4.48 0 1 0 3.12 4.2V0z"></path></svg>';
+    }
+    if (lower.includes('youtube')) {
+        return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M21.6 6.2a2.7 2.7 0 0 0-1.9-1.9C17.8 4 12 4 12 4s-5.8 0-7.7.3A2.7 2.7 0 0 0 2.4 6.2 28.9 28.9 0 0 0 2 12a28.9 28.9 0 0 0 .4 5.8 2.7 2.7 0 0 0 1.9 1.9C6.2 19.9 12 19.9 12 19.9s5.8 0 7.7-.3a2.7 2.7 0 0 0 1.9-1.9 28.9 28.9 0 0 0 .4-5.8 28.9 28.9 0 0 0-.4-5.7zM10 15.5v-7l6 3.5-6 3.5z"></path></svg>';
+    }
+    if (lower.includes('facebook')) {
+        return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M14 9h3V6h-3c-2.2 0-4 1.8-4 4v2H7v3h3v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z"></path></svg>';
+    }
+    return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 14.5h-2V11h2zm0-6h-2V8h2z"></path></svg>';
+}
+
+function loadSocialLinks() {
+    const container = document.querySelector('[data-social-links]');
+    if (!container) return;
+    const errorBox = document.querySelector('[data-social-error]');
+
+    fetchJson('/links')
+        .then(data => {
+            const links = data && Array.isArray(data.links) ? data.links : [];
+            const socials = links.filter(link => link.category === 'social' && link.is_active);
+            if (socials.length === 0) {
+                return;
+            }
+
+            container.innerHTML = '';
+            socials.forEach(link => {
+                const anchor = document.createElement('a');
+                anchor.className = 'social-link';
+                anchor.href = link.url;
+                anchor.target = '_blank';
+                anchor.rel = 'noopener noreferrer';
+                anchor.setAttribute('aria-label', link.label);
+                anchor.innerHTML = `${getSocialIconMarkup(link.url)}<span class="sr-only">${link.label}</span>`;
+                container.appendChild(anchor);
+            });
+            setHidden(errorBox, true);
+        })
+        .catch(() => {
+            if (errorBox) {
+                errorBox.textContent = 'Tidak dapat memuat tautan sosial.';
+                setHidden(errorBox, false);
+            }
+        });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadEvents();
+    loadTestimonials();
+    loadPartners();
+    loadSocialLinks();
+});
 
 // Mouse wheel horizontal scroll for desktop
 document.querySelectorAll('.sponsor-carousel').forEach(carousel => {

--- a/legacy/php/style.css
+++ b/legacy/php/style.css
@@ -1163,3 +1163,162 @@ footer {
 
 .social-icons a svg { fill: currentColor; }   /* for inline SVG */
 .social-icons a i { color: currentColor; }    /* for Font Awesome <i> */
+
+/* --- CMS dynamic content styles --- */
+.dynamic-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    margin-top: 32px;
+}
+
+.dynamic-grid--testimonials {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.dynamic-grid--partners {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dynamic-placeholder {
+    text-align: center;
+    border: 1px dashed rgba(0, 0, 0, 0.15);
+    border-radius: 16px;
+    padding: 24px;
+    color: var(--gray, #555);
+    background: rgba(255, 255, 255, 0.6);
+    margin-top: 24px;
+}
+
+.dynamic-error {
+    margin-top: 20px;
+    padding: 16px;
+    border-radius: 14px;
+    background: rgba(208, 49, 45, 0.12);
+    color: #7c0f18;
+    text-align: center;
+}
+
+.dynamic-error--inline {
+    margin-top: 12px;
+    font-size: 0.95rem;
+}
+
+.dynamic-card {
+    background: #fff;
+    border-radius: 20px;
+    box-shadow: 0 22px 40px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    display: grid;
+    grid-template-rows: auto 1fr;
+}
+
+.dynamic-card__media img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    display: block;
+}
+
+.dynamic-card__avatar {
+    width: 76px;
+    height: 76px;
+    border-radius: 50%;
+    overflow: hidden;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+    margin: 24px auto 0;
+}
+
+.dynamic-card__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.dynamic-card__body {
+    display: grid;
+    gap: 14px;
+    padding: 24px;
+}
+
+.dynamic-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 18px;
+    color: var(--gray, #666);
+    font-size: 0.9rem;
+}
+
+.dynamic-card__title {
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--black, #111);
+}
+
+.dynamic-card__text {
+    margin: 0;
+    line-height: 1.6;
+    color: var(--gray, #555);
+}
+
+.dynamic-card__quote {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--gray, #444);
+}
+
+.dynamic-card__author {
+    display: grid;
+    gap: 4px;
+    font-weight: 600;
+}
+
+.dynamic-card__author .dynamic-card__meta {
+    font-weight: 500;
+    font-size: 0.9rem;
+}
+
+.dynamic-card__link {
+    font-weight: 600;
+    color: var(--primary-red, #8F1D1D);
+    text-decoration: none;
+}
+
+.dynamic-card--testimonial {
+    text-align: center;
+    padding-top: 12px;
+}
+
+.dynamic-card--partner {
+    text-align: center;
+    align-content: center;
+}
+
+.dynamic-card--partner .dynamic-card__media img {
+    height: 120px;
+    object-fit: contain;
+    filter: saturate(0.9);
+}
+
+.dynamic-card--partner .dynamic-card__body {
+    gap: 10px;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 768px) {
+    .dynamic-grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- build a new marketing landing page in the Next.js workspace that consumes CMS APIs for events, testimonials, partners, and social links
- add client components and styling for the public sections and remove the previous /cms base path so the app can ship at the root domain
- wire the legacy PHP homepage to read the same CMS JSON endpoints and render dynamic cards with new styles and error handling

## Testing
- `npm run lint --workspace web` *(fails: `next` command missing because dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8dec0329883289d59f62bdb0571b9