### PR TITLE
feat: fetch gallery media from CMS

### DIFF
--- a/apps/web/app/(public)/galeri/page.js
+++ b/apps/web/app/(public)/galeri/page.js
@@ -1,4 +1,5 @@
 import { LegacyShell } from '../../../components/legacy/LegacyShell';
+import { GalleryGrid } from '../../../components/legacy/GalleryGrid';
 
 export const metadata = {
   title: 'Galeri — Komunitas Chinese Indonesia',
@@ -56,52 +57,7 @@ export default function GaleriPage() {
             <p className="section-subtitle">Kumpulan momen kegiatan Komunitas Chinese Indonesia</p>
           </div>
 
-          <div className="gallery-grid">
-            <figure className="gallery-card">
-              <img
-                className="gallery-image"
-                src="/assets/events/basketbersamakci.jpg"
-                alt="Basket bersama KCI"
-                width={1600}
-                height={1200}
-                loading="lazy"
-              />
-              <figcaption className="gallery-caption">
-                <h3>Basket Bersama KCI</h3>
-                <p>Kebersamaan melalui olahraga bareng.</p>
-              </figcaption>
-            </figure>
-
-            <figure className="gallery-card">
-              <img
-                className="gallery-image"
-                src="/assets/events/nontonbersamakci.jpg"
-                alt="Nonton bersama KCI"
-                width={1600}
-                height={1200}
-                loading="lazy"
-              />
-              <figcaption className="gallery-caption">
-                <h3>Nonton Bersama</h3>
-                <p>Menikmati film bareng komunitas.</p>
-              </figcaption>
-            </figure>
-
-            <figure className="gallery-card">
-              <img
-                className="gallery-image"
-                src="/assets/events/zoombersamakci.jpg"
-                alt="Zoom bersama KCI"
-                width={1600}
-                height={1200}
-                loading="lazy"
-              />
-              <figcaption className="gallery-caption">
-                <h3>Zoom Bersama</h3>
-                <p>Diskusi daring &amp; koordinasi acara.</p>
-              </figcaption>
-            </figure>
-          </div>
+          <GalleryGrid />
         </div>
       </section>
 

--- a/apps/web/components/legacy/GalleryGrid.js
+++ b/apps/web/components/legacy/GalleryGrid.js
@@ -1,0 +1,50 @@
+'use client';
+
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+function GalleryCard({ item }) {
+  const metadata = item.metadata || {};
+  const altText = metadata.alt || item.title || 'Dokumentasi KCI';
+  const description = item.description || metadata.subtitle;
+
+  return (
+    <figure className="gallery-card">
+      {item.asset_url ? (
+        <img className="gallery-image" src={item.asset_url} alt={altText} loading="lazy" />
+      ) : (
+        <div className="gallery-image" aria-hidden="true" />
+      )}
+      <figcaption className="gallery-caption">
+        <h3>{item.title || 'Dokumentasi KCI'}</h3>
+        {description ? <p>{description}</p> : null}
+      </figcaption>
+    </figure>
+  );
+}
+
+export function GalleryGrid() {
+  const { data, error, isLoading } = useSWR('/media/gallery', () => apiGet('/media/gallery'));
+  const items = data?.items ?? [];
+  const hasItems = items.length > 0;
+
+  return (
+    <>
+      <div className="gallery-grid" data-gallery-list hidden={!hasItems || isLoading}>
+        {items.map((item) => (
+          <GalleryCard key={item.id} item={item} />
+        ))}
+      </div>
+      <div className="dynamic-placeholder" data-gallery-empty hidden={hasItems || error || isLoading}>
+        <p>No documentation yet.</p>
+        <p>Silakan kembali lagi nanti untuk melihat momen terbaru.</p>
+      </div>
+      <div className="dynamic-placeholder" hidden={!isLoading}>
+        <p>Memuat dokumentasi…</p>
+      </div>
+      <div className="dynamic-error" data-gallery-error hidden={!error}>
+        Gagal memuat dokumentasi.
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side GalleryGrid component that loads gallery media via the CMS
- swap the galeri page's hard-coded figures for the dynamic grid with loading, error, and empty fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9f41722d8832886b6c5bcab3d2a5a