### PR TITLE
Add media file upload support

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,5 +6,6 @@ DATA_DIR=./apps/api/data
 # Supabase configuration can be provided later when the hosted database is ready
 # SUPABASE_URL=https://your-project.supabase.co
 # SUPABASE_SERVICE_ROLE_KEY=service_role_key_here
+# SUPABASE_STORAGE_BUCKET=media-library
 # Optional DSN to pull data from the existing MySQL instance during migration
 # LEGACY_MYSQL_DSN=mysql://user:password@host:3306/database

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
+    "@fastify/multipart": "^7.7.0",
     "@fastify/sensible": "^5.6.0",
     "@supabase/supabase-js": "^2.45.4",
     "fastify": "^4.28.1",

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -14,6 +14,7 @@ const EnvSchema = z.object({
   API_PORT: z.coerce.number().default(3000),
   SUPABASE_URL: z.string().url().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
+  SUPABASE_STORAGE_BUCKET: z.string().min(1).default('media-library'),
   LEGACY_MYSQL_DSN: z.string().optional(),
   DATA_DIR: z.string().default(defaultDataDir),
 });
@@ -39,6 +40,7 @@ export const env = {
     ? {
         url: envVars.SUPABASE_URL,
         serviceRoleKey: envVars.SUPABASE_SERVICE_ROLE_KEY,
+        storageBucket: envVars.SUPABASE_STORAGE_BUCKET,
       }
     : null,
   legacy: {

--- a/apps/api/src/modules/media/routes.ts
+++ b/apps/api/src/modules/media/routes.ts
@@ -1,13 +1,136 @@
+import multipart from '@fastify/multipart';
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { FastifyInstance } from 'fastify';
+import { env } from '../../config/env.js';
+import { getSupabaseClient } from '../../lib/supabase.js';
 import { MediaService, UpsertMediaSchema } from './service.js';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const appsDir = path.resolve(moduleDir, '../../../..');
+const LOCAL_UPLOAD_ROOT = path.resolve(appsDir, 'web/public/uploads');
+
+function sanitizeSegment(value?: string | null) {
+  if (!value) {
+    return 'media';
+  }
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized || 'media';
+}
+
+function buildFileName(originalName?: string) {
+  const ext = originalName ? path.extname(originalName) : '';
+  const safeExt = ext ? ext.toLowerCase() : '';
+  return `${Date.now()}-${randomUUID()}${safeExt}`;
+}
+
+async function storeFileLocally(folder: string, fileName: string, buffer: Buffer) {
+  const targetDir = path.join(LOCAL_UPLOAD_ROOT, folder);
+  await mkdir(targetDir, { recursive: true });
+  const targetPath = path.join(targetDir, fileName);
+  await writeFile(targetPath, buffer);
+  const relativePath = `${folder}/${fileName}`;
+  return {
+    publicUrl: `/uploads/${relativePath}`,
+    storageKey: relativePath,
+  };
+}
+
+async function storeFileInSupabase(folder: string, fileName: string, buffer: Buffer, mimeType?: string | null) {
+  const supabase = getSupabaseClient();
+  const bucket = env.supabase?.storageBucket ?? 'media-library';
+  const objectKey = `${folder}/${fileName}`;
+
+  const uploadResult = await supabase.storage.from(bucket).upload(objectKey, buffer, {
+    contentType: mimeType ?? 'application/octet-stream',
+    upsert: false,
+  });
+
+  if (uploadResult.error) {
+    throw uploadResult.error;
+  }
+
+  const publicUrlResult = supabase.storage.from(bucket).getPublicUrl(objectKey);
+  if (publicUrlResult.error) {
+    throw publicUrlResult.error;
+  }
+
+  const publicUrl = publicUrlResult.data.publicUrl;
+  if (!publicUrl) {
+    throw new Error('Failed to resolve public URL for uploaded file.');
+  }
+
+  return {
+    publicUrl,
+    storageKey: objectKey,
+  };
+}
 
 export async function mediaRoutes(server: FastifyInstance) {
   const service = new MediaService();
+
+  await server.register(multipart, {
+    limits: {
+      fileSize: 25 * 1024 * 1024,
+    },
+  });
 
   server.get('/:type', async (request) => {
     const { type } = request.params as { type: 'gallery' | 'testimonial' | 'partner' };
     const items = await service.listByType(type);
     return { items };
+  });
+
+  server.post('/upload', async (request) => {
+    const file = await request.file();
+
+    if (!file) {
+      throw server.httpErrors.badRequest('No file uploaded');
+    }
+
+    const buffer = await file.toBuffer();
+    if (buffer.length === 0) {
+      throw server.httpErrors.badRequest('Uploaded file is empty');
+    }
+
+    const fieldType = typeof file.fields?.type?.value === 'string' ? file.fields?.type?.value : null;
+    const folder = sanitizeSegment(fieldType);
+    const fileName = buildFileName(file.filename);
+    const baseMetadata = {
+      originalName: file.filename,
+      mimeType: file.mimetype,
+      size: buffer.length,
+      folder,
+    };
+
+    try {
+      if (env.supabase) {
+        const { publicUrl, storageKey } = await storeFileInSupabase(folder, fileName, buffer, file.mimetype);
+        return {
+          url: publicUrl,
+          metadata: {
+            ...baseMetadata,
+            storage: 'supabase' as const,
+            storageKey,
+          },
+        };
+      }
+
+      const { publicUrl, storageKey } = await storeFileLocally(folder, fileName, buffer);
+      return {
+        url: publicUrl,
+        metadata: {
+          ...baseMetadata,
+          storage: 'local' as const,
+          storageKey,
+        },
+      };
+    } catch (error) {
+      request.log.error({ err: error }, 'Failed to store media upload');
+      throw server.httpErrors.internalServerError('Failed to store uploaded file');
+    }
   });
 
   server.post('/', async (request) => {

--- a/apps/web/lib/api.js
+++ b/apps/web/lib/api.js
@@ -1,11 +1,17 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '/api';
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '/api';
 
 async function request(path, options = {}) {
   const url = `${API_BASE}${path}`;
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(options.headers || {}),
-  };
+  const isFormData =
+    typeof FormData !== 'undefined' && options.body instanceof FormData;
+  const headers = isFormData
+    ? {
+        ...(options.headers || {}),
+      }
+    : {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      };
 
   const response = await fetch(url, {
     ...options,
@@ -39,6 +45,13 @@ export function apiPost(path, body) {
   return request(path, {
     method: 'POST',
     body: JSON.stringify(body),
+  });
+}
+
+export function apiUpload(path, formData) {
+  return request(path, {
+    method: 'POST',
+    body: formData,
   });
 }
 


### PR DESCRIPTION
## Summary
- enable multipart handling for media uploads, persisting files to Supabase storage when configured or to the local uploads directory while returning the public URL
- relax media asset validation to accept stored paths, merge metadata updates, and surface a configurable Supabase storage bucket
- add an admin drag-and-drop uploader that posts multipart form data and reuses the returned URL alongside manual entry support

## Testing
- not run (npm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68d9f63cc0b48328b72f225f5dc8bdbc