### PR TITLE
Add contacts CMS management

### DIFF
--- a/apps/api/data/contacts.json
+++ b/apps/api/data/contacts.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "name": "Founder KCI",
+    "role": "Pendiri Komunitas",
+    "phone": "+62 878-8492-4385",
+    "whatsapp_url": "https://wa.me/6287884924385",
+    "photo_url": "/assets/profile/founder-profile.jpg"
+  },
+  {
+    "id": 2,
+    "name": "Admin KCI",
+    "role": "Administrasi & Informasi Kegiatan",
+    "phone": "+62 856-4187-7775",
+    "whatsapp_url": "https://wa.me/6285641877775",
+    "photo_url": "/assets/profile/admin-kci-profile.jpg"
+  }
+]

--- a/apps/api/src/modules/contacts/routes.ts
+++ b/apps/api/src/modules/contacts/routes.ts
@@ -1,0 +1,38 @@
+import { FastifyInstance } from 'fastify';
+import { ContactsService, UpsertContactSchema } from './service.js';
+
+export async function contactsRoutes(server: FastifyInstance) {
+  const service = new ContactsService();
+
+  server.get('/', async () => ({ contacts: await service.listContacts() }));
+
+  server.post('/', async (request) => {
+    const payload = UpsertContactSchema.parse(request.body);
+    try {
+      const contact = await service.upsertContact(payload);
+      return { contact };
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Contact not found') {
+        throw server.httpErrors.notFound(error.message);
+      }
+      throw error;
+    }
+  });
+
+  server.delete('/:id', async (request) => {
+    const { id } = request.params as { id: string };
+    const numericId = Number(id);
+    if (!Number.isInteger(numericId) || numericId <= 0) {
+      throw server.httpErrors.badRequest('Contact id must be a positive integer');
+    }
+    try {
+      await service.deleteContact(numericId);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Contact not found') {
+        throw server.httpErrors.notFound(error.message);
+      }
+      throw error;
+    }
+    return { success: true };
+  });
+}

--- a/apps/api/src/modules/contacts/service.ts
+++ b/apps/api/src/modules/contacts/service.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod';
+import { nextId, readTable, writeTable } from '../../lib/json-store.js';
+
+const TABLE = 'contacts';
+
+const OptionalTextSchema = z
+  .preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }, z.string().trim().min(1).nullable());
+
+const UrlLikeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch (error) {
+      return value.startsWith('/');
+    }
+  }, { message: 'URL must be absolute (http/https) or start with /' });
+
+const OptionalUrlSchema = z.preprocess((value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}, UrlLikeSchema.nullable());
+
+export const ContactSchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string(),
+  role: z.string().nullable(),
+  phone: z.string().nullable(),
+  whatsapp_url: z.string().nullable(),
+  photo_url: z.string().nullable(),
+});
+
+export type ContactRecord = z.infer<typeof ContactSchema>;
+
+export const UpsertContactSchema = z.object({
+  id: z.number().int().positive().optional(),
+  name: z.string().trim().min(1),
+  role: OptionalTextSchema.optional(),
+  phone: OptionalTextSchema.optional(),
+  whatsapp_url: OptionalUrlSchema.optional(),
+  photo_url: OptionalUrlSchema.optional(),
+});
+
+export type UpsertContactInput = z.infer<typeof UpsertContactSchema>;
+
+const FALLBACK_CONTACTS: ContactRecord[] = [
+  {
+    id: 1,
+    name: 'Founder KCI',
+    role: 'Pendiri Komunitas',
+    phone: '+62 878-8492-4385',
+    whatsapp_url: 'https://wa.me/6287884924385',
+    photo_url: '/assets/profile/founder-profile.jpg',
+  },
+  {
+    id: 2,
+    name: 'Admin KCI',
+    role: 'Administrasi & Informasi Kegiatan',
+    phone: '+62 856-4187-7775',
+    whatsapp_url: 'https://wa.me/6285641877775',
+    photo_url: '/assets/profile/admin-kci-profile.jpg',
+  },
+];
+
+function buildContactRecord(id: number, input: UpsertContactInput, existing?: ContactRecord): ContactRecord {
+  return {
+    id,
+    name: input.name.trim(),
+    role: typeof input.role === 'string' ? input.role : existing?.role ?? null,
+    phone: typeof input.phone === 'string' ? input.phone : existing?.phone ?? null,
+    whatsapp_url:
+      typeof input.whatsapp_url === 'string'
+        ? input.whatsapp_url
+        : existing?.whatsapp_url ?? null,
+    photo_url: typeof input.photo_url === 'string' ? input.photo_url : existing?.photo_url ?? null,
+  };
+}
+
+export class ContactsService {
+  async listContacts() {
+    const contacts = await readTable<ContactRecord>(TABLE, FALLBACK_CONTACTS);
+    return z.array(ContactSchema).parse(contacts);
+  }
+
+  async upsertContact(input: UpsertContactInput) {
+    const payload = UpsertContactSchema.parse(input);
+    const contacts = await readTable<ContactRecord>(TABLE, FALLBACK_CONTACTS);
+
+    if (payload.id) {
+      const existing = contacts.find((contact) => contact.id === payload.id);
+      if (!existing) {
+        throw new Error('Contact not found');
+      }
+      const updated = buildContactRecord(existing.id, payload, existing);
+      const nextContacts = contacts.map((contact) =>
+        contact.id === updated.id ? updated : contact
+      );
+      await writeTable(TABLE, nextContacts);
+      return ContactSchema.parse(updated);
+    }
+
+    const newId = nextId(contacts);
+    const record = buildContactRecord(newId, payload);
+    const nextContacts = [...contacts, record];
+    await writeTable(TABLE, nextContacts);
+    return ContactSchema.parse(record);
+  }
+
+  async deleteContact(id: number) {
+    const contacts = await readTable<ContactRecord>(TABLE, FALLBACK_CONTACTS);
+    const exists = contacts.some((contact) => contact.id === id);
+    if (!exists) {
+      throw new Error('Contact not found');
+    }
+    const nextContacts = contacts.filter((contact) => contact.id !== id);
+    await writeTable(TABLE, nextContacts);
+    return { success: true } as const;
+  }
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { authRoutes } from '../modules/auth/routes.js';
 import { eventsRoutes } from '../modules/events/routes.js';
+import { contactsRoutes } from '../modules/contacts/routes.js';
 import { mediaRoutes } from '../modules/media/routes.js';
 import { messagingRoutes } from '../modules/messaging/routes.js';
 import { linksRoutes } from '../modules/links/routes.js';
@@ -8,6 +9,7 @@ import { linksRoutes } from '../modules/links/routes.js';
 export async function registerRoutes(server: FastifyInstance) {
   await server.register(authRoutes, { prefix: '/auth' });
   await server.register(eventsRoutes, { prefix: '/events' });
+  await server.register(contactsRoutes, { prefix: '/contacts' });
   await server.register(mediaRoutes, { prefix: '/media' });
   await server.register(messagingRoutes, { prefix: '/messaging' });
   await server.register(linksRoutes, { prefix: '/links' });

--- a/apps/web/app/(public)/HomePageClient.js
+++ b/apps/web/app/(public)/HomePageClient.js
@@ -1,10 +1,12 @@
 'use client';
 
+import useSWR from 'swr';
 import { EventsGrid } from '../../components/legacy/EventsGrid';
 import { LegacyShell, useLegacyLinkGroups } from '../../components/legacy/LegacyShell';
 import { PartnersGrid } from '../../components/legacy/PartnersGrid';
 import { SocialLinks } from '../../components/legacy/SocialLinks';
 import { TestimonialsGrid } from '../../components/legacy/TestimonialsGrid';
+import { apiGet } from '../../lib/api';
 
 const DEFAULT_PRIMARY_LINKS = [
   { href: '#beranda', label: 'Beranda' },
@@ -23,6 +25,29 @@ const DEFAULT_SECONDARY_LINKS = [
   { href: '/galeri', label: 'Galeri' },
   { href: '#kontak', label: 'Kontak' },
 ];
+
+const DEFAULT_CONTACTS = [
+  {
+    id: 'founder',
+    name: 'Founder KCI',
+    role: 'Pendiri Komunitas',
+    phone: '+62 878-8492-4385',
+    whatsapp_url: 'https://wa.me/6287884924385',
+    photo_url: '/assets/profile/founder-profile.jpg',
+  },
+  {
+    id: 'admin',
+    name: 'Admin KCI',
+    role: 'Administrasi & Informasi Kegiatan',
+    phone: '+62 856-4187-7775',
+    whatsapp_url: 'https://wa.me/6285641877775',
+    photo_url: '/assets/profile/admin-kci-profile.jpg',
+  },
+];
+
+function toTelHref(phone = '') {
+  return phone.replace(/[^0-9+]/g, '');
+}
 
 function isExternalHref(href = '') {
   return /^https?:/i.test(href);
@@ -48,6 +73,9 @@ export function HomePageClient() {
   const { groups } = useLegacyLinkGroups();
   const primaryGroup = groups?.primary ?? [];
   const secondaryGroup = groups?.secondary ?? [];
+  const { data: contactsData } = useSWR('/contacts', () => apiGet('/contacts'));
+  const contacts = contactsData?.contacts ?? [];
+  const contactCards = contacts.length > 0 ? contacts : DEFAULT_CONTACTS;
 
   const navLinks = primaryGroup.length > 0 ? primaryGroup : DEFAULT_PRIMARY_LINKS;
   const footerLinks = secondaryGroup.length > 0 ? secondaryGroup : DEFAULT_SECONDARY_LINKS;
@@ -156,39 +184,36 @@ export function HomePageClient() {
           </div>
 
           <div className="contact-grid">
-            <div className="contact-card">
-              <div className="contact-avatar">
-                <img
-                  src="/assets/profile/founder-profile.jpg"
-                  alt="Founder KCI"
-                  width={600}
-                  height={600}
-                  loading="lazy"
-                />
+            {contactCards.map((contact) => (
+              <div key={contact.id} className="contact-card">
+                <div className="contact-avatar">
+                  {contact.photo_url ? (
+                    <img src={contact.photo_url} alt={contact.name} width={600} height={600} loading="lazy" />
+                  ) : (
+                    <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--gray)' }}>
+                      {contact.name?.[0] ?? '?'}
+                    </span>
+                  )}
+                </div>
+                <h3>{contact.name}</h3>
+                {contact.role ? <p>{contact.role}</p> : null}
+                {contact.phone ? (
+                  <p>
+                    <a href={`tel:${toTelHref(contact.phone)}`}>{contact.phone}</a>
+                  </p>
+                ) : null}
+                {contact.whatsapp_url ? (
+                  <a
+                    href={contact.whatsapp_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn-whatsapp"
+                  >
+                    Hubungi via WhatsApp
+                  </a>
+                ) : null}
               </div>
-              <h3>Founder KCI</h3>
-              <p>Hubungi pendiri komunitas untuk informasi lebih lanjut tentang visi dan misi KCI</p>
-              <a href="https://wa.me/6287884924385" target="_blank" rel="noopener noreferrer" className="btn-whatsapp">
-                Hubungi via WhatsApp
-              </a>
-            </div>
-
-            <div className="contact-card">
-              <div className="contact-avatar">
-                <img
-                  src="/assets/profile/admin-kci-profile.jpg"
-                  alt="Admin KCI"
-                  width={600}
-                  height={600}
-                  loading="lazy"
-                />
-              </div>
-              <h3>Admin KCI</h3>
-              <p>Kontak admin untuk keperluan administrasi, pendaftaran, dan informasi kegiatan</p>
-              <a href="https://wa.me/6285641877775" target="_blank" rel="noopener noreferrer" className="btn-whatsapp">
-                Hubungi via WhatsApp
-              </a>
-            </div>
+            ))}
           </div>
 
           <div className="social-container" style={{ textAlign: 'center', marginTop: '24px' }}>

--- a/apps/web/app/admin/contacts/page.js
+++ b/apps/web/app/admin/contacts/page.js
@@ -1,0 +1,302 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { MediaLibraryPicker } from '../../../components/admin/MediaLibraryPicker';
+import { apiDelete, apiGet, apiPost } from '../../../lib/api';
+
+function createEmptyContact() {
+  return {
+    id: null,
+    name: '',
+    role: '',
+    phone: '',
+    whatsapp_url: '',
+    photo_url: '',
+  };
+}
+
+export default function ContactsPage() {
+  const { data, error, isLoading, mutate } = useSWR('/contacts', () => apiGet('/contacts'));
+  const contacts = useMemo(() => data?.contacts ?? [], [data]);
+
+  const [showModal, setShowModal] = useState(false);
+  const [draft, setDraft] = useState(() => createEmptyContact());
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  function openCreate() {
+    setDraft(createEmptyContact());
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function openEdit(contact) {
+    setDraft({
+      id: contact.id,
+      name: contact.name ?? '',
+      role: contact.role ?? '',
+      phone: contact.phone ?? '',
+      whatsapp_url: contact.whatsapp_url ?? '',
+      photo_url: contact.photo_url ?? '',
+    });
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function closeModal() {
+    setShowModal(false);
+    setSaving(false);
+    setFormError('');
+  }
+
+  function updateField(field, value) {
+    setDraft((previous) => ({ ...previous, [field]: value }));
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSaving(true);
+    setFormError('');
+
+    const payload = {
+      id: draft.id ?? undefined,
+      name: draft.name.trim(),
+      role: draft.role.trim() ? draft.role.trim() : null,
+      phone: draft.phone.trim() ? draft.phone.trim() : null,
+      whatsapp_url: draft.whatsapp_url.trim() ? draft.whatsapp_url.trim() : null,
+      photo_url: draft.photo_url.trim() ? draft.photo_url.trim() : null,
+    };
+
+    try {
+      await apiPost('/contacts', payload);
+      await mutate();
+      closeModal();
+    } catch (err) {
+      setFormError(err.message || 'Failed to save contact');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(contact) {
+    if (!window.confirm(`Delete contact "${contact.name}"?`)) {
+      return;
+    }
+    try {
+      await apiDelete(`/contacts/${contact.id}`);
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to delete contact');
+    }
+  }
+
+  function openMediaPicker() {
+    setPickerOpen(true);
+  }
+
+  function closeMediaPicker() {
+    setPickerOpen(false);
+  }
+
+  function handleMediaSelect(item) {
+    updateField('photo_url', item.asset_url || '');
+    closeMediaPicker();
+  }
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Contacts</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Manage the contact cards displayed on the public site. Add WhatsApp links and phone numbers for quick access.
+          </p>
+        </div>
+        <button className="button" onClick={openCreate}>
+          New contact
+        </button>
+      </header>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading contacts…</p>
+      ) : contacts.length === 0 ? (
+        <div className="empty-state">No contacts yet. Add your first team member.</div>
+      ) : (
+        <div className="stack">
+          {contacts.map((contact) => (
+            <div key={contact.id} className="card">
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 1fr auto',
+                  gap: '1rem',
+                  alignItems: 'center',
+                }}
+              >
+                <div
+                  style={{
+                    width: '80px',
+                    height: '80px',
+                    borderRadius: '9999px',
+                    overflow: 'hidden',
+                    background: '#f3f4f6',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '0.85rem',
+                    color: '#555',
+                  }}
+                >
+                  {contact.photo_url ? (
+                    <img
+                      src={contact.photo_url}
+                      alt={contact.name}
+                      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                    />
+                  ) : (
+                    <span>No photo</span>
+                  )}
+                </div>
+                <div className="stack" style={{ gap: '0.35rem' }}>
+                  <div>
+                    <strong>{contact.name}</strong>
+                    {contact.role ? <span style={{ display: 'block', color: '#555' }}>{contact.role}</span> : null}
+                  </div>
+                  {contact.phone ? (
+                    <span style={{ color: '#555' }}>
+                      Phone: <a href={`tel:${contact.phone.replace(/\s+/g, '')}`}>{contact.phone}</a>
+                    </span>
+                  ) : null}
+                  {contact.whatsapp_url ? (
+                    <a href={contact.whatsapp_url} target="_blank" rel="noreferrer" style={{ color: '#1f6feb' }}>
+                      WhatsApp link
+                    </a>
+                  ) : null}
+                </div>
+                <div className="stack" style={{ gap: '0.5rem' }}>
+                  <button className="button secondary" onClick={() => openEdit(contact)}>
+                    Edit
+                  </button>
+                  <button className="button" onClick={() => handleDelete(contact)}>
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showModal ? (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <div className="modal">
+            <header className="stack" style={{ marginBottom: '1rem' }}>
+              <h2 style={{ margin: 0 }}>{draft.id ? 'Edit contact' : 'Add contact'}</h2>
+              <p style={{ margin: 0, color: '#555' }}>
+                Provide the contact details that should appear on the website. All fields except name are optional.
+              </p>
+            </header>
+            {formError ? <div className="alert">{formError}</div> : null}
+            <form className="stack" onSubmit={handleSubmit}>
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="contact-name">Name</label>
+                  <input
+                    id="contact-name"
+                    type="text"
+                    value={draft.name}
+                    onChange={(event) => updateField('name', event.target.value)}
+                    required
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="contact-role">Role / Title</label>
+                  <input
+                    id="contact-role"
+                    type="text"
+                    value={draft.role}
+                    onChange={(event) => updateField('role', event.target.value)}
+                    placeholder="e.g. Founder"
+                  />
+                </div>
+              </div>
+
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="contact-phone">Phone number</label>
+                  <input
+                    id="contact-phone"
+                    type="text"
+                    value={draft.phone}
+                    onChange={(event) => updateField('phone', event.target.value)}
+                    placeholder="e.g. +62 812-1234-5678"
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="contact-whatsapp">WhatsApp link</label>
+                  <input
+                    id="contact-whatsapp"
+                    type="url"
+                    value={draft.whatsapp_url}
+                    onChange={(event) => updateField('whatsapp_url', event.target.value)}
+                    placeholder="https://wa.me/..."
+                  />
+                </div>
+              </div>
+
+              <div className="stack">
+                <div className="input-group">
+                  <label htmlFor="contact-photo">Photo URL</label>
+                  <input
+                    id="contact-photo"
+                    type="url"
+                    value={draft.photo_url}
+                    onChange={(event) => updateField('photo_url', event.target.value)}
+                    placeholder="https://example.com/avatar.jpg"
+                  />
+                </div>
+                <div>
+                  <button type="button" className="button secondary" onClick={openMediaPicker}>
+                    Choose from media library
+                  </button>
+                </div>
+                {draft.photo_url ? (
+                  <div
+                    style={{
+                      width: '120px',
+                      height: '120px',
+                      borderRadius: '9999px',
+                      overflow: 'hidden',
+                      border: '1px solid #e5e7eb',
+                    }}
+                  >
+                    <img
+                      src={draft.photo_url}
+                      alt={draft.name || 'Selected avatar'}
+                      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                    />
+                  </div>
+                ) : null}
+              </div>
+
+              <footer style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem' }}>
+                <button type="button" className="button secondary" onClick={closeModal} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="submit" className="button" disabled={saving}>
+                  {saving ? 'Saving…' : 'Save contact'}
+                </button>
+              </footer>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      <MediaLibraryPicker open={pickerOpen} onClose={closeMediaPicker} onSelect={handleMediaSelect} />
+    </section>
+  );
+}

--- a/apps/web/app/admin/layout.js
+++ b/apps/web/app/admin/layout.js
@@ -8,6 +8,7 @@ import { clearSession, getSession } from '../../lib/session';
 const NAV_ITEMS = [
   { href: '/admin/events', label: 'Events' },
   { href: '/admin/media', label: 'Media' },
+  { href: '/admin/contacts', label: 'Contacts' },
   { href: '/admin/links', label: 'Links' },
   { href: '/admin/messages', label: 'Messages' },
 ];

--- a/apps/web/components/admin/MediaLibraryPicker.js
+++ b/apps/web/components/admin/MediaLibraryPicker.js
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { apiGet } from '../../lib/api';
+
+const MEDIA_TYPES = [
+  { value: 'testimonial', label: 'Testimonials' },
+  { value: 'partner', label: 'Partners' },
+  { value: 'gallery', label: 'Gallery' },
+];
+
+function MediaList({ type, onSelect }) {
+  const { data, error, isLoading } = useSWR(`/media/${type}`, () => apiGet(`/media/${type}`));
+  const items = useMemo(() => data?.items ?? [], [data]);
+
+  if (error) {
+    return <div className="alert">{error.message}</div>;
+  }
+
+  if (isLoading) {
+    return <p>Loading media…</p>;
+  }
+
+  if (items.length === 0) {
+    return <div className="empty-state">No media in this group yet.</div>;
+  }
+
+  return (
+    <div className="stack">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className="card"
+          style={{ textAlign: 'left', display: 'grid', gridTemplateColumns: '96px 1fr auto', gap: '1rem', alignItems: 'center' }}
+          onClick={() => onSelect(item)}
+        >
+          <div
+            style={{
+              width: '96px',
+              height: '96px',
+              borderRadius: '0.75rem',
+              overflow: 'hidden',
+              background: '#f3f4f6',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '1px solid #e5e7eb',
+            }}
+          >
+            {item.asset_url ? (
+              <img src={item.asset_url} alt={item.title || 'Media asset'} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <span style={{ color: '#555' }}>No preview</span>
+            )}
+          </div>
+          <div className="stack" style={{ gap: '0.35rem' }}>
+            <strong>{item.title || 'Untitled asset'}</strong>
+            {item.description ? <span style={{ color: '#555' }}>{item.description}</span> : null}
+            <span style={{ fontSize: '0.85rem', color: '#1f6feb', wordBreak: 'break-all' }}>{item.asset_url}</span>
+          </div>
+          <span className="badge" style={{ justifySelf: 'flex-start' }}>
+            Select
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function MediaLibraryPicker({ open, onClose, onSelect }) {
+  const [activeType, setActiveType] = useState(MEDIA_TYPES[0]?.value ?? 'testimonial');
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handler = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal" style={{ maxWidth: '720px' }}>
+        <header className="stack" style={{ marginBottom: '1rem' }}>
+          <h2 style={{ margin: 0 }}>Choose media</h2>
+          <p style={{ margin: 0, color: '#555' }}>
+            Pick an image from the media library. You can manage assets from the Media section of the admin panel.
+          </p>
+        </header>
+
+        <div className="tabs" role="tablist" style={{ marginBottom: '1rem' }}>
+          {MEDIA_TYPES.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              role="tab"
+              aria-selected={activeType === item.value}
+              className={`tab ${activeType === item.value ? 'active' : ''}`}
+              onClick={() => setActiveType(item.value)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ maxHeight: '420px', overflowY: 'auto', paddingRight: '0.5rem' }}>
+          <MediaList type={activeType} onSelect={(item) => onSelect(item)} />
+        </div>
+
+        <footer style={{ marginTop: '1rem', display: 'flex', justifyContent: 'flex-end' }}>
+          <button type="button" className="button secondary" onClick={onClose}>
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a contacts JSON-store table with service and routes for listing, upserting, and deleting contact records
- seed initial contact data and register the new module with the API router
- build a contacts admin UI with media library picker support and load CMS contacts on the public homepage with a static fallback

## Testing
- npm --workspace apps-api run test *(fails: `vitest` binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fbf575948328ad639b82731a70b6