### PR TITLE
Add blog posts API and web interfaces

### DIFF
--- a/apps/api/src/modules/posts/routes.ts
+++ b/apps/api/src/modules/posts/routes.ts
@@ -1,0 +1,41 @@
+import { FastifyInstance } from 'fastify';
+import { PostsService, UpsertPostSchema } from './service.js';
+
+function parseIncludeDrafts(value: string | undefined) {
+  if (!value) {
+    return false;
+  }
+  return value === '1' || value.toLowerCase() === 'true';
+}
+
+export async function postsRoutes(server: FastifyInstance) {
+  const service = new PostsService();
+
+  server.get('/', async (request) => {
+    const { includeDrafts } = request.query as { includeDrafts?: string };
+    const posts = await service.listPosts({ includeDrafts: parseIncludeDrafts(includeDrafts) });
+    return { posts };
+  });
+
+  server.get('/:slug', async (request) => {
+    const { slug } = request.params as { slug: string };
+    const { includeDrafts } = request.query as { includeDrafts?: string };
+    const post = await service.getPostBySlug(slug, { includeDrafts: parseIncludeDrafts(includeDrafts) });
+    if (!post) {
+      throw server.httpErrors.notFound('Post not found');
+    }
+    return { post };
+  });
+
+  server.post('/', async (request) => {
+    const payload = UpsertPostSchema.parse(request.body);
+    const post = await service.upsertPost(payload);
+    return { post };
+  });
+
+  server.delete('/:id', async (request) => {
+    const { id } = request.params as { id: string };
+    await service.deletePost(Number(id));
+    return { success: true };
+  });
+}

--- a/apps/api/src/modules/posts/service.ts
+++ b/apps/api/src/modules/posts/service.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod';
+import { nextId, readTable, writeTable } from '../../lib/json-store.js';
+
+const TABLE = 'posts';
+
+export const PostSchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string(),
+  slug: z.string(),
+  summary: z.string().nullable(),
+  body: z.string(),
+  cover_image_url: z.string().url().nullable(),
+  published_at: z.string().datetime().nullable(),
+  is_published: z.boolean(),
+});
+
+export type PostRecord = z.infer<typeof PostSchema>;
+
+export const UpsertPostSchema = PostSchema.partial({
+  id: true,
+  is_published: true,
+}).extend({
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  body: z.string().min(1),
+});
+
+export type UpsertPostInput = z.infer<typeof UpsertPostSchema>;
+
+function normalizePublishedAt(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  try {
+    return new Date(value).toISOString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function buildPostRecord(id: number, input: UpsertPostInput, existing?: PostRecord): PostRecord {
+  return {
+    id,
+    title: input.title ?? existing?.title ?? '',
+    slug: input.slug ?? existing?.slug ?? '',
+    summary: input.summary ?? existing?.summary ?? null,
+    body: input.body ?? existing?.body ?? '',
+    cover_image_url: input.cover_image_url ?? existing?.cover_image_url ?? null,
+    published_at:
+      normalizePublishedAt(input.published_at) ?? existing?.published_at ?? null,
+    is_published: input.is_published ?? existing?.is_published ?? false,
+  };
+}
+
+function sortPosts(posts: PostRecord[]) {
+  return [...posts].sort((a, b) => {
+    const aDate = a.published_at ?? '';
+    const bDate = b.published_at ?? '';
+
+    if (aDate && bDate) {
+      return bDate.localeCompare(aDate);
+    }
+    if (aDate) {
+      return -1;
+    }
+    if (bDate) {
+      return 1;
+    }
+    return a.title.localeCompare(b.title);
+  });
+}
+
+interface ListPostsOptions {
+  includeDrafts?: boolean;
+}
+
+interface GetPostOptions {
+  includeDrafts?: boolean;
+}
+
+export class PostsService {
+  async listPosts(options: ListPostsOptions = {}) {
+    const posts = await readTable<PostRecord>(TABLE);
+    const filtered = options.includeDrafts
+      ? posts
+      : posts.filter((post) => post.is_published);
+    const sorted = sortPosts(filtered);
+    return z.array(PostSchema).parse(sorted);
+  }
+
+  async getPostBySlug(slug: string, options: GetPostOptions = {}) {
+    const posts = await readTable<PostRecord>(TABLE);
+    const post = posts.find((item) => item.slug === slug);
+    if (!post) {
+      return null;
+    }
+    if (!options.includeDrafts && !post.is_published) {
+      return null;
+    }
+    return PostSchema.parse(post);
+  }
+
+  async upsertPost(input: UpsertPostInput) {
+    const payload = UpsertPostSchema.parse(input);
+    const posts = await readTable<PostRecord>(TABLE);
+
+    if (payload.id) {
+      const existing = posts.find((post) => post.id === payload.id);
+      if (!existing) {
+        throw new Error('Post not found');
+      }
+      const updated = buildPostRecord(existing.id, payload, existing);
+      const nextPosts = posts.map((post) => (post.id === updated.id ? updated : post));
+      await writeTable(TABLE, nextPosts);
+      return PostSchema.parse(updated);
+    }
+
+    const newId = nextId(posts);
+    const record = buildPostRecord(newId, payload);
+    const nextPosts = [...posts, record];
+    await writeTable(TABLE, nextPosts);
+    return PostSchema.parse(record);
+  }
+
+  async deletePost(id: number) {
+    const posts = await readTable<PostRecord>(TABLE);
+    const filtered = posts.filter((post) => post.id !== id);
+    if (filtered.length === posts.length) {
+      throw new Error('Post not found');
+    }
+    await writeTable(TABLE, filtered);
+  }
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -5,6 +5,7 @@ import { contactsRoutes } from '../modules/contacts/routes.js';
 import { mediaRoutes } from '../modules/media/routes.js';
 import { messagingRoutes } from '../modules/messaging/routes.js';
 import { linksRoutes } from '../modules/links/routes.js';
+import { postsRoutes } from '../modules/posts/routes.js';
 
 export async function registerRoutes(server: FastifyInstance) {
   await server.register(authRoutes, { prefix: '/auth' });
@@ -13,4 +14,5 @@ export async function registerRoutes(server: FastifyInstance) {
   await server.register(mediaRoutes, { prefix: '/media' });
   await server.register(messagingRoutes, { prefix: '/messaging' });
   await server.register(linksRoutes, { prefix: '/links' });
+  await server.register(postsRoutes, { prefix: '/posts' });
 }

--- a/apps/web/app/(public)/HomePageClient.js
+++ b/apps/web/app/(public)/HomePageClient.js
@@ -14,6 +14,7 @@ const DEFAULT_PRIMARY_LINKS = [
   { href: '/tentang_kci', label: 'Tentang' },
   { href: '#acara', label: 'Acara' },
   { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
   { href: '#testimoni', label: 'Testimoni' },
   { href: '#kontak', label: 'Kontak' },
   { href: '#sponsor', label: 'Partner' },
@@ -23,6 +24,7 @@ const DEFAULT_SECONDARY_LINKS = [
   { href: '#visi-misi', label: 'Visi & Misi' },
   { href: '#acara', label: 'Acara' },
   { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
   { href: '#kontak', label: 'Kontak' },
 ];
 

--- a/apps/web/app/(public)/blog/BlogPageClient.js
+++ b/apps/web/app/(public)/blog/BlogPageClient.js
@@ -1,0 +1,229 @@
+'use client';
+
+import Link from 'next/link';
+import useSWR from 'swr';
+import { LegacyShell } from '../../../components/legacy/LegacyShell';
+import { apiGet } from '../../../lib/api';
+
+const NAV_LINKS = [
+  { href: '/#beranda', label: 'Beranda' },
+  { href: '/#visi-misi', label: 'Visi Misi' },
+  { href: '/tentang_kci', label: 'Tentang' },
+  { href: '/#acara', label: 'Acara' },
+  { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/#testimoni', label: 'Testimoni' },
+  { href: '/#kontak', label: 'Kontak' },
+  { href: '/#sponsor', label: 'Partner' },
+];
+
+function formatDate(isoString) {
+  if (!isoString) {
+    return null;
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString('id-ID', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Asia/Jakarta',
+  });
+}
+
+function PostCard({ post }) {
+  const publishedDate = formatDate(post.published_at);
+  return (
+    <article className="blog-card">
+      {post.cover_image_url ? (
+        <Link href={`/blog/${post.slug}`} className="blog-card__image">
+          <img src={post.cover_image_url} alt={post.title} loading="lazy" />
+        </Link>
+      ) : null}
+      <div className="blog-card__content">
+        {publishedDate ? <span className="blog-card__date">{publishedDate}</span> : null}
+        <h3>
+          <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+        </h3>
+        {post.summary ? <p>{post.summary}</p> : null}
+        <Link className="blog-card__cta" href={`/blog/${post.slug}`}>
+          Baca selengkapnya →
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+export function BlogPageClient() {
+  const { data, error, isLoading } = useSWR('/posts', () => apiGet('/posts'));
+  const posts = data?.posts ?? [];
+
+  return (
+    <LegacyShell navLinks={NAV_LINKS} variant="home">
+      <style>{`
+        .blog-hero {
+          background: linear-gradient(135deg, rgba(143, 29, 29, 0.92), rgba(192, 46, 46, 0.85)), url('/assets/texture.png');
+          color: white;
+          padding: 120px 0 80px;
+          text-align: center;
+        }
+        .blog-hero h1 {
+          font-size: clamp(2rem, 4vw, 3rem);
+          margin-bottom: 1rem;
+        }
+        .blog-hero p {
+          max-width: 640px;
+          margin: 0 auto;
+          font-size: 1.1rem;
+          color: rgba(255, 255, 255, 0.9);
+        }
+        .blog-grid {
+          display: grid;
+          gap: 32px;
+          grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+        .blog-card {
+          background: white;
+          border-radius: 18px;
+          border: 1px solid var(--border-color);
+          overflow: hidden;
+          box-shadow: var(--shadow);
+          display: flex;
+          flex-direction: column;
+        }
+        .blog-card__image {
+          display: block;
+          width: 100%;
+          aspect-ratio: 16 / 9;
+          overflow: hidden;
+          background: var(--light-gray);
+        }
+        .blog-card__image img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+        }
+        .blog-card__content {
+          padding: 20px 22px 24px;
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .blog-card__content h3 {
+          font-size: 1.35rem;
+          margin: 0;
+        }
+        .blog-card__content h3 a {
+          text-decoration: none;
+          color: inherit;
+        }
+        .blog-card__content h3 a:hover {
+          color: var(--primary-red);
+        }
+        .blog-card__date {
+          font-size: 0.9rem;
+          color: var(--gray);
+          letter-spacing: 0.02em;
+        }
+        .blog-card__cta {
+          align-self: flex-start;
+          color: var(--primary-red);
+          font-weight: 600;
+          text-decoration: none;
+        }
+        .blog-card__cta:hover {
+          text-decoration: underline;
+        }
+        .blog-empty {
+          text-align: center;
+          padding: 80px 0;
+          color: var(--gray);
+          border-radius: 18px;
+          background: rgba(255, 255, 255, 0.75);
+          border: 1px dashed var(--border-color);
+        }
+      `}</style>
+
+      <section className="blog-hero">
+        <div className="container">
+          <h1>Blog Komunitas Chinese Indonesia</h1>
+          <p>
+            Jelajahi cerita, pembaruan, dan wawasan terbaru dari komunitas kami. Temukan kisah inspiratif dan kegiatan
+            terbaru KCI.
+          </p>
+        </div>
+      </section>
+
+      <section className="section" style={{ paddingTop: '48px' }}>
+        <div className="container" style={{ color: 'var(--gray)', fontSize: '0.95rem' }}>
+          <span>
+            <a className="nav-link" href="/" style={{ padding: 0, fontWeight: 600 }}>
+              Beranda
+            </a>{' '}
+            › Blog
+          </span>
+        </div>
+      </section>
+
+      <section className="section section-alt" style={{ paddingTop: '36px' }}>
+        <div className="container">
+          {error ? (
+            <div className="alert">{error.message}</div>
+          ) : isLoading ? (
+            <p>Memuat artikel…</p>
+          ) : posts.length === 0 ? (
+            <div className="blog-empty">Belum ada artikel yang dipublikasikan.</div>
+          ) : (
+            <div className="blog-grid">
+              {posts.map((post) => (
+                <PostCard key={post.id} post={post} />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <footer>
+        <div className="container">
+          <div className="footer-content">
+            <div className="footer-section">
+              <h3>Komunitas Chinese Indonesia</h3>
+              <p>文化连心，共创未来</p>
+            </div>
+            <div className="footer-section">
+              <h3>Tautan Cepat</h3>
+              <p>
+                <a href="/#visi-misi">Visi &amp; Misi</a>
+              </p>
+              <p>
+                <a href="/#acara">Acara</a>
+              </p>
+              <p>
+                <a href="/galeri">Galeri</a>
+              </p>
+              <p>
+                <a href="/blog">Blog</a>
+              </p>
+              <p>
+                <a href="/#kontak">Kontak</a>
+              </p>
+            </div>
+            <div className="footer-section">
+              <h3>Hubungi Kami</h3>
+              <p>Founder: 0878-8492-4385</p>
+              <p>Admin: 0856-4187-7775</p>
+              <p>Instagram: @komunitaschineseindonesia</p>
+            </div>
+          </div>
+          <div className="footer-bottom">
+            <p>&copy; {new Date().getFullYear()} Komunitas Chinese Indonesia. All rights reserved.</p>
+            <p>Unity in Diversity - Bhinneka Tunggal Ika</p>
+          </div>
+        </div>
+      </footer>
+    </LegacyShell>
+  );
+}

--- a/apps/web/app/(public)/blog/[slug]/BlogPostPageClient.js
+++ b/apps/web/app/(public)/blog/[slug]/BlogPostPageClient.js
@@ -1,0 +1,192 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { LegacyShell } from '../../../../components/legacy/LegacyShell';
+import { apiGet } from '../../../../lib/api';
+
+const NAV_LINKS = [
+  { href: '/#beranda', label: 'Beranda' },
+  { href: '/#visi-misi', label: 'Visi Misi' },
+  { href: '/tentang_kci', label: 'Tentang' },
+  { href: '/#acara', label: 'Acara' },
+  { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/#testimoni', label: 'Testimoni' },
+  { href: '/#kontak', label: 'Kontak' },
+  { href: '/#sponsor', label: 'Partner' },
+];
+
+function formatDate(isoString) {
+  if (!isoString) {
+    return null;
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString('id-ID', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Asia/Jakarta',
+  });
+}
+
+function renderBody(body = '') {
+  const paragraphs = body.split(/\n{2,}/).map((chunk) => chunk.trim()).filter(Boolean);
+  if (paragraphs.length === 0) {
+    return <p>Tidak ada konten untuk ditampilkan.</p>;
+  }
+  return paragraphs.map((paragraph, index) => (
+    <p key={index}>{paragraph}</p>
+  ));
+}
+
+export function BlogPostPageClient({ slug }) {
+  const { data, error, isLoading } = useSWR(`/posts/${slug}`, () => apiGet(`/posts/${slug}`));
+  const post = data?.post;
+  const publishedDate = useMemo(() => formatDate(post?.published_at), [post?.published_at]);
+  const isNotFound = error?.message?.toLowerCase().includes('not found');
+
+  return (
+    <LegacyShell navLinks={NAV_LINKS} variant="home">
+      <style>{`
+        .blog-post-hero {
+          background: linear-gradient(135deg, rgba(143, 29, 29, 0.92), rgba(192, 46, 46, 0.85));
+          color: white;
+          padding: 120px 0 60px;
+        }
+        .blog-post-hero .breadcrumbs {
+          color: rgba(255, 255, 255, 0.9);
+          font-size: 0.95rem;
+          margin-bottom: 12px;
+        }
+        .blog-post-hero h1 {
+          margin: 0;
+          font-size: clamp(2.2rem, 5vw, 3.2rem);
+          line-height: 1.1;
+        }
+        .blog-post-hero .meta {
+          margin-top: 1.5rem;
+          font-size: 1rem;
+          color: rgba(255, 255, 255, 0.85);
+        }
+        .blog-post-content {
+          background: white;
+          border-radius: 22px;
+          box-shadow: var(--shadow);
+          padding: clamp(24px, 4vw, 48px);
+          margin-top: -60px;
+          position: relative;
+          z-index: 2;
+        }
+        .blog-post-content img {
+          width: 100%;
+          max-height: 480px;
+          object-fit: cover;
+          border-radius: 18px;
+          margin-bottom: 2rem;
+        }
+        .blog-post-body {
+          display: grid;
+          gap: 1.5rem;
+          font-size: 1.05rem;
+          line-height: 1.8;
+          color: #2c2c2c;
+        }
+        .blog-post-empty {
+          padding: 80px 0;
+          text-align: center;
+          color: var(--gray);
+        }
+      `}</style>
+
+      {error && !isNotFound ? (
+        <section className="section">
+          <div className="container">
+            <div className="alert">{error.message}</div>
+          </div>
+        </section>
+      ) : isLoading ? (
+        <section className="section">
+          <div className="container">
+            <p>Memuat artikel…</p>
+          </div>
+        </section>
+      ) : !post ? (
+        <section className="section">
+          <div className="container">
+            <div className="blog-post-empty">
+              Artikel tidak ditemukan atau belum dipublikasikan.
+            </div>
+          </div>
+        </section>
+      ) : (
+        <>
+          <section className="blog-post-hero">
+            <div className="container">
+              <div className="breadcrumbs">
+                <Link href="/">Beranda</Link> › <Link href="/blog">Blog</Link> › <span>{post.title}</span>
+              </div>
+              <h1>{post.title}</h1>
+              {post.summary ? <p style={{ marginTop: '1rem', maxWidth: '720px' }}>{post.summary}</p> : null}
+              {publishedDate ? <div className="meta">Diterbitkan pada {publishedDate}</div> : null}
+            </div>
+          </section>
+
+          <section className="section">
+            <div className="container">
+              <article className="blog-post-content">
+                {post.cover_image_url ? (
+                  <img src={post.cover_image_url} alt={post.title} loading="lazy" />
+                ) : null}
+                <div className="blog-post-body">{renderBody(post.body)}</div>
+              </article>
+            </div>
+          </section>
+        </>
+      )}
+
+      <footer>
+        <div className="container">
+          <div className="footer-content">
+            <div className="footer-section">
+              <h3>Komunitas Chinese Indonesia</h3>
+              <p>文化连心，共创未来</p>
+            </div>
+            <div className="footer-section">
+              <h3>Tautan Cepat</h3>
+              <p>
+                <a href="/#visi-misi">Visi &amp; Misi</a>
+              </p>
+              <p>
+                <a href="/#acara">Acara</a>
+              </p>
+              <p>
+                <a href="/galeri">Galeri</a>
+              </p>
+              <p>
+                <a href="/blog">Blog</a>
+              </p>
+              <p>
+                <a href="/#kontak">Kontak</a>
+              </p>
+            </div>
+            <div className="footer-section">
+              <h3>Hubungi Kami</h3>
+              <p>Founder: 0878-8492-4385</p>
+              <p>Admin: 0856-4187-7775</p>
+              <p>Instagram: @komunitaschineseindonesia</p>
+            </div>
+          </div>
+          <div className="footer-bottom">
+            <p>&copy; {new Date().getFullYear()} Komunitas Chinese Indonesia. All rights reserved.</p>
+            <p>Unity in Diversity - Bhinneka Tunggal Ika</p>
+          </div>
+        </div>
+      </footer>
+    </LegacyShell>
+  );
+}

--- a/apps/web/app/(public)/blog/[slug]/page.js
+++ b/apps/web/app/(public)/blog/[slug]/page.js
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation';
+import { BlogPostPageClient } from './BlogPostPageClient';
+
+export function generateMetadata({ params }) {
+  const titleFromSlug = params?.slug?.replace(/[-_]+/g, ' ') || 'Blog';
+  const capitalized = titleFromSlug
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+  return {
+    title: `${capitalized} — Blog — Komunitas Chinese Indonesia`,
+  };
+}
+
+export default function BlogPostPage({ params }) {
+  if (!params?.slug) {
+    notFound();
+  }
+  return <BlogPostPageClient slug={params.slug} />;
+}

--- a/apps/web/app/(public)/blog/page.js
+++ b/apps/web/app/(public)/blog/page.js
@@ -1,0 +1,10 @@
+import { BlogPageClient } from './BlogPageClient';
+
+export const metadata = {
+  title: 'Blog — Komunitas Chinese Indonesia',
+  description: 'Artikel terbaru, cerita komunitas, dan pembaruan Komunitas Chinese Indonesia (KCI).',
+};
+
+export default function BlogPage() {
+  return <BlogPageClient />;
+}

--- a/apps/web/app/(public)/galeri/page.js
+++ b/apps/web/app/(public)/galeri/page.js
@@ -12,6 +12,7 @@ const NAV_LINKS = [
   { href: '/tentang_kci', label: 'Tentang' },
   { href: '/#acara', label: 'Acara' },
   { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
   { href: '/#testimoni', label: 'Testimoni' },
   { href: '/#kontak', label: 'Kontak' },
   { href: '/#sponsor', label: 'Partner' },
@@ -104,6 +105,9 @@ export default function GaleriPage() {
               </p>
               <p>
                 <a href="/galeri">Galeri</a>
+              </p>
+              <p>
+                <a href="/blog">Blog</a>
               </p>
               <p>
                 <a href="/#kontak">Kontak</a>

--- a/apps/web/app/(public)/tentang_kci/page.js
+++ b/apps/web/app/(public)/tentang_kci/page.js
@@ -11,6 +11,7 @@ const NAV_LINKS = [
   { href: '/tentang_kci', label: 'Tentang' },
   { href: '/#acara', label: 'Acara' },
   { href: '/galeri', label: 'Galeri' },
+  { href: '/blog', label: 'Blog' },
   { href: '/#testimoni', label: 'Testimoni' },
   { href: '/#kontak', label: 'Kontak' },
   { href: '/#sponsor', label: 'Partner' },
@@ -197,6 +198,9 @@ export default function TentangPage() {
               </p>
               <p>
                 <a href="/tentang_kci">Tentang</a>
+              </p>
+              <p>
+                <a href="/blog">Blog</a>
               </p>
               <p>
                 <a href="/#kontak">Kontak</a>

--- a/apps/web/app/admin/layout.js
+++ b/apps/web/app/admin/layout.js
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { clearSession, getSession } from '../../lib/session';
 
 const NAV_ITEMS = [
+  { href: '/admin/posts', label: 'Posts' },
   { href: '/admin/events', label: 'Events' },
   { href: '/admin/media', label: 'Media' },
   { href: '/admin/contacts', label: 'Contacts' },

--- a/apps/web/app/admin/page.js
+++ b/apps/web/app/admin/page.js
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function AdminIndexPage() {
-  redirect('/admin/events');
+  redirect('/admin/posts');
 }

--- a/apps/web/app/admin/posts/page.js
+++ b/apps/web/app/admin/posts/page.js
@@ -1,0 +1,374 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { MediaLibraryPicker } from '../../../components/admin/MediaLibraryPicker';
+import { apiDelete, apiGet, apiPost } from '../../../lib/api';
+
+function createEmptyPost() {
+  return {
+    title: '',
+    slug: '',
+    summary: '',
+    body: '',
+    cover_image_url: '',
+    published_at: '',
+    is_published: false,
+  };
+}
+
+function toDateInputValue(isoString) {
+  if (!isoString) {
+    return '';
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function fromDateInputValue(value) {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+export default function PostsAdminPage() {
+  const key = '/posts?includeDrafts=1';
+  const { data, error, isLoading, mutate } = useSWR(key, () => apiGet(key));
+  const posts = useMemo(() => data?.posts ?? [], [data]);
+
+  const [showModal, setShowModal] = useState(false);
+  const [formError, setFormError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [draft, setDraft] = useState(() => createEmptyPost());
+  const [editingId, setEditingId] = useState(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
+
+  function openCreate() {
+    setDraft(createEmptyPost());
+    setEditingId(null);
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function openEdit(post) {
+    setDraft({
+      ...post,
+      summary: post.summary ?? '',
+      body: post.body ?? '',
+      cover_image_url: post.cover_image_url ?? '',
+      published_at: toDateInputValue(post.published_at),
+    });
+    setEditingId(post.id);
+    setFormError('');
+    setShowModal(true);
+  }
+
+  function closeModal() {
+    setShowModal(false);
+    setSaving(false);
+    setFormError('');
+  }
+
+  function updateField(field, value) {
+    setDraft((previous) => ({ ...previous, [field]: value }));
+  }
+
+  function handleMediaSelect(item) {
+    if (!item) {
+      return;
+    }
+    updateField('cover_image_url', item.asset_url || '');
+    setPickerOpen(false);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setSaving(true);
+    setFormError('');
+
+    const payload = {
+      id: editingId ?? undefined,
+      title: draft.title,
+      slug: draft.slug,
+      summary: draft.summary || null,
+      body: draft.body,
+      cover_image_url: draft.cover_image_url || null,
+      is_published: draft.is_published,
+      published_at: fromDateInputValue(draft.published_at),
+    };
+
+    try {
+      await apiPost('/posts', payload);
+      await mutate();
+      closeModal();
+    } catch (err) {
+      setFormError(err.message || 'Failed to save post');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function togglePublish(postRecord) {
+    const nextPublished = !postRecord.is_published;
+    const nextPublishedAt = nextPublished
+      ? postRecord.published_at || new Date().toISOString()
+      : postRecord.published_at || null;
+
+    try {
+      await apiPost('/posts', {
+        id: postRecord.id,
+        title: postRecord.title,
+        slug: postRecord.slug,
+        summary: postRecord.summary ?? null,
+        body: postRecord.body,
+        cover_image_url: postRecord.cover_image_url ?? null,
+        is_published: nextPublished,
+        published_at: nextPublishedAt,
+      });
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to update publish status');
+    }
+  }
+
+  async function deletePost(postRecord) {
+    const confirmed = window.confirm(`Delete post "${postRecord.title}"? This action cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+    setDeletingId(postRecord.id);
+    try {
+      await apiDelete(`/posts/${postRecord.id}`);
+      await mutate();
+    } catch (err) {
+      alert(err.message || 'Failed to delete post');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <section>
+      <header className="action-bar">
+        <div>
+          <h1 style={{ margin: 0 }}>Posts</h1>
+          <p style={{ margin: 0, color: '#555' }}>
+            Create and manage blog entries. Publish posts to make them visible on the public blog.
+          </p>
+        </div>
+        <button className="button" onClick={openCreate}>
+          New post
+        </button>
+      </header>
+
+      {error ? <div className="alert">{error.message}</div> : null}
+
+      {isLoading ? (
+        <p>Loading posts…</p>
+      ) : posts.length === 0 ? (
+        <div className="empty-state">No posts yet. Start by creating a new post.</div>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Published on</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {posts.map((post) => (
+              <tr key={post.id}>
+                <td>
+                  <div className="stack">
+                    <strong>{post.title}</strong>
+                    <span style={{ color: '#666', fontSize: '0.875rem' }}>{post.slug}</span>
+                  </div>
+                </td>
+                <td>
+                  {post.published_at
+                    ? new Date(post.published_at).toLocaleDateString('en-US', { timeZone: 'Asia/Jakarta' })
+                    : '—'}
+                </td>
+                <td>
+                  <span
+                    className="badge"
+                    style={{
+                      background: post.is_published ? '#dcfce7' : '#fee2e2',
+                      color: post.is_published ? '#166534' : '#7f1d1d',
+                    }}
+                  >
+                    {post.is_published ? 'Published' : 'Draft'}
+                  </span>
+                </td>
+                <td>
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    <button className="button secondary" onClick={() => openEdit(post)}>
+                      Edit
+                    </button>
+                    <button className="button" onClick={() => togglePublish(post)}>
+                      {post.is_published ? 'Unpublish' : 'Publish'}
+                    </button>
+                    <button
+                      className="button secondary"
+                      onClick={() => deletePost(post)}
+                      disabled={deletingId === post.id}
+                    >
+                      {deletingId === post.id ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {showModal ? (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <div className="modal" style={{ maxWidth: '720px' }}>
+            <header className="stack" style={{ marginBottom: '1rem' }}>
+              <h2 style={{ margin: 0 }}>{editingId ? 'Edit post' : 'Create post'}</h2>
+              <p style={{ margin: 0, color: '#555' }}>
+                Provide the post details below. The publish date helps order posts on the public blog.
+              </p>
+            </header>
+            {formError ? <div className="alert">{formError}</div> : null}
+            <form className="form-grid" onSubmit={handleSubmit}>
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="title">Title</label>
+                  <input
+                    id="title"
+                    type="text"
+                    required
+                    value={draft.title}
+                    onChange={(event) => updateField('title', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="slug">Slug</label>
+                  <input
+                    id="slug"
+                    type="text"
+                    required
+                    value={draft.slug}
+                    onChange={(event) => updateField('slug', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="summary">Summary</label>
+                <textarea
+                  id="summary"
+                  rows={3}
+                  value={draft.summary}
+                  onChange={(event) => updateField('summary', event.target.value)}
+                />
+              </div>
+
+              <div className="input-group">
+                <label htmlFor="body">Body</label>
+                <textarea
+                  id="body"
+                  rows={10}
+                  required
+                  value={draft.body}
+                  onChange={(event) => updateField('body', event.target.value)}
+                />
+              </div>
+
+              <div className="form-grid two-col">
+                <div className="input-group">
+                  <label htmlFor="published_at">Publish date</label>
+                  <input
+                    id="published_at"
+                    type="date"
+                    value={draft.published_at}
+                    onChange={(event) => updateField('published_at', event.target.value)}
+                  />
+                </div>
+                <div className="input-group">
+                  <label htmlFor="cover_image">Cover image URL</label>
+                  <div className="stack" style={{ gap: '0.5rem' }}>
+                    <input
+                      id="cover_image"
+                      type="url"
+                      value={draft.cover_image_url}
+                      onChange={(event) => updateField('cover_image_url', event.target.value)}
+                    />
+                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <button type="button" className="button secondary" onClick={() => setPickerOpen(true)}>
+                        Choose from media library
+                      </button>
+                      {draft.cover_image_url ? (
+                        <button
+                          type="button"
+                          className="button secondary"
+                          onClick={() => updateField('cover_image_url', '')}
+                        >
+                          Remove image
+                        </button>
+                      ) : null}
+                    </div>
+                    {draft.cover_image_url ? (
+                      <div
+                        style={{
+                          border: '1px solid #e5e7eb',
+                          borderRadius: '0.75rem',
+                          overflow: 'hidden',
+                          width: '100%',
+                          maxWidth: '320px',
+                        }}
+                      >
+                        <img
+                          src={draft.cover_image_url}
+                          alt="Selected cover"
+                          style={{ width: '100%', display: 'block', objectFit: 'cover' }}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  checked={draft.is_published}
+                  onChange={(event) => updateField('is_published', event.target.checked)}
+                />
+                <span>Published</span>
+              </label>
+
+              <div className="actions">
+                <button type="button" className="button secondary" onClick={closeModal} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="submit" className="button" disabled={saving}>
+                  {saving ? 'Saving…' : 'Save post'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      <MediaLibraryPicker open={pickerOpen} onClose={() => setPickerOpen(false)} onSelect={handleMediaSelect} />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a posts module with JSON-store persistence and CRUD endpoints, then register it with the API router
- build an admin posts screen that supports creating, editing, publishing, and deleting entries with media library integration
- expose public blog listing and detail pages and link them from existing navigation menus

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9ff0e609483288fc27e955c622768