### PR TITLE
Add Passenger entrypoint and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,15 @@ Lightweight CMS API with session auth and JSON-backed storage for local testing 
 npm install
 cp apps/api/.env.example apps/api/.env
 # (Windows PowerShell: Copy-Item apps/api/.env.example apps/api/.env)
+```
 
+## Deployment
+
+Before starting the Passenger app, install dependencies and compile the API build:
+
+```bash
+npm install
+npm --workspace apps-api run build
+```
+
+Configure Passenger to launch the compiled server by running `node apps/api/server.mjs` as the application entrypoint.

--- a/apps/api/server.mjs
+++ b/apps/api/server.mjs
@@ -1,0 +1,1 @@
+import './dist/index.js';


### PR DESCRIPTION
## Summary
- add a Passenger-compatible server entrypoint that imports the compiled API build
- document deployment steps to install dependencies, build the API workspace, and point Passenger at the new entry script

## Testing
- npm --workspace apps-api run build *(fails: existing TypeScript errors in src/modules/media/routes.ts)*
- node apps/api/server.mjs


------
https://chatgpt.com/codex/tasks/task_e_68db748c81e483289ff897ac5e03f8cb